### PR TITLE
feat: configurable PrototypeStrategy for prototype-mode scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ In your `mycroft.conf`:
 * `model`: Path to your pretrained Model2Vec model or huggingface repo.
 * `conf_xxx`: Minimum confidence threshold for intent matching.
 * `ignore_intents`: List of intents to ignore during matching.
+* `prototype_strategy`: Scoring strategy for prototype mode (`"max_over_all"` default — back-compatible). See [docs/strategies.md](docs/strategies.md).
+* `prototype_top_k`: Top-k cosines averaged by the `top_k_mean` strategy (default `3`).
+* `prototype_tau`: Softmax temperature for the `softmax_weighted` strategy (default `0.1`).
 
 > ⚠️  The Model2Vec model is pretrained based on GitLocalize exports and **cannot learn new skills** dynamically.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,6 +38,9 @@ Any bare `StaticModel` on Hugging Face (or a local path) can be used as the embe
       "model": "Jarbas/ovos-model2vec-intents-LaBSE",
       "mode": "classifier",
       "prototype_k": 5,
+      "prototype_strategy": "max_over_all",
+      "prototype_top_k": 3,
+      "prototype_tau": 0.1,
       "conf_high": 0.7,
       "conf_medium": 0.5,
       "conf_low": 0.15,
@@ -55,11 +58,30 @@ Any bare `StaticModel` on Hugging Face (or a local path) can be used as the embe
 | `model` | `str` | `"Jarbas/ovos-model2vec-intents-distiluse-base-multilingual-cased-v2"` | Hugging Face repo ID or local path. In classifier mode this must be a `StaticModelPipeline`; in prototype mode any bare `StaticModel` works. |
 | `mode` | `str` | `"classifier"` | Operating mode: `"classifier"` or `"prototype"`. |
 | `prototype_k` | `int` | `5` | Maximum number of prototype embeddings stored per intent label (prototype mode only). |
+| `prototype_strategy` | `str` | `"max_over_all"` | Scoring strategy for prototype mode. See [Prototype Strategies](#prototype-strategies-prototype-mode-only) below. |
+| `prototype_top_k` | `int` | `3` | Number of top cosine similarities averaged by the `top_k_mean` strategy. Also the default `k` for `softmax_weighted` when used in scoring. |
+| `prototype_tau` | `float` | `0.1` | Temperature for the `softmax_weighted` strategy. Lower values sharpen the distribution toward the maximum; higher values flatten it toward the mean. |
 | `conf_high` | `float` | `0.7` | Minimum score for a `match_high` result. |
 | `conf_medium` | `float` | `0.5` | Minimum score for a `match_medium` result. |
 | `conf_low` | `float` | `0.15` | Minimum score for a `match_low` result. |
 | `ignore_intents` | `list[str]` | `[]` | Intent labels to always discard, regardless of confidence. |
 | `timeout` | `int` | `1` | Seconds to wait for Adapt / Padatious manifest responses (classifier mode only). |
+
+## Prototype Strategies (prototype mode only)
+
+`prototype_strategy` selects the algorithm used to aggregate a label's sample embeddings into match scores. Defined in `ovos_m2v_pipeline/strategies.py:51` as `PrototypeStrategy`.
+
+| Value | Storage | Scoring | Notes |
+|-------|---------|---------|-------|
+| `max_over_all` | Up to `prototype_k` samples per label (random subsample) | Max cosine over stored anchors | Default. Back-compatible with pre-strategy behaviour. |
+| `mean_centroid` | 1 anchor = mean of all samples | Cosine to centroid | Cheapest storage and inference; classic prototype baseline. |
+| `medoid` | 1 anchor = sample closest to centroid | Cosine to medoid | Robust to outliers; avoids averaging blur. |
+| `top_k_mean` | All samples kept | Mean of top-`prototype_top_k` cosines | Combines sharpness of max with smoothing. |
+| `farthest_point` | Up to `prototype_k` samples via maximin sampling | Max cosine | Anchors span the example space; good for diverse phrasings. |
+| `kmeans_centers` | Up to `prototype_k` spherical k-means centroids | Max cosine | Useful when a label has multi-modal phrasings. |
+| `softmax_weighted` | All samples kept | Softmax-weighted average of cosines | `prototype_tau` controls sharpness. |
+
+The default `max_over_all` produces byte-identical results to the store behaviour before strategies were introduced — existing `.npz` files and tuned thresholds remain valid.
 
 ## Confidence Thresholds
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,8 +24,8 @@ The pipeline is designed as a **fallback or confidence-based matcher** — it is
 
 1. At boot, each `padatious:register_intent` bus event carries the path to a `.intent` file with example utterances (or an inline `samples` list).
 2. The examples are template-expanded (e.g. `(turn on|switch on) the lights`) and embedded with the bare `StaticModel`.
-3. Up to `prototype_k` embeddings per label are stored in the `PrototypeIntentStore`.
-4. At inference time, the query embedding is compared to every stored prototype via cosine similarity; the highest per-label score is used.
+3. `select_anchors()` reduces the embeddings to the subset or aggregation dictated by `prototype_strategy`; up to `prototype_k` anchors per label are stored in `PrototypeIntentStore`.
+4. At inference time, `score_labels()` turns the query embedding into one score per label according to the active `PrototypeStrategy`.
 
 ## Key Properties
 
@@ -43,5 +43,6 @@ The pipeline is designed as a **fallback or confidence-based matcher** — it is
 | [OVOS Pipeline Plugin](ovos_pipeline.md) | Entry points, bus events, mixing plugins, confidence tiers |
 | [Configuration](configuration.md) | All configuration options |
 | [Pipeline Internals](pipeline.md) | Architecture and runtime behaviour |
+| [Prototype Strategies](strategies.md) | Scoring strategy reference for prototype mode |
 | [Models](models.md) | Available pre-trained models and benchmark results |
 | [Training](training.md) | How to gather data and train/retrain models |

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -80,7 +80,7 @@ Called for every `padatious:register_intent` event. Steps:
 3. Apply `ovos_utils.bracket_expansion.expand_template` to every line so that template syntax is expanded into concrete utterances:
    - `(turn on|switch on) the lights` → `["turn on the lights", "switch on the lights"]`
    - `[please] play music` → `["please play music", "play music"]`
-4. Embed up to `prototype_k` examples and add/replace them in `PrototypeIntentStore`.
+4. Embed all expanded examples; `select_anchors()` (`ovos_m2v_pipeline/strategies.py:131`) reduces them to the subset or aggregation dictated by `prototype_strategy`. Up to `prototype_k` anchors per label are stored in `PrototypeIntentStore`.
 5. Add the label to `self.intents`.
 
 ### `_handle_register_adapt`
@@ -99,25 +99,38 @@ Removes all prototypes whose label starts with `<skill_id>:` and removes matchin
 
 ## `PrototypeIntentStore`
 
-A mutable store of L2-normalised prototype embeddings. The store starts empty and is populated incrementally at runtime.
+Defined in `ovos_m2v_pipeline/__init__.py:34`. A mutable store of L2-normalised prototype embeddings. The store starts empty and is populated incrementally at runtime.
 
 ```python
-store = PrototypeIntentStore()
+from ovos_m2v_pipeline.strategies import PrototypeStrategy
+
+store = PrototypeIntentStore(
+    strategy=PrototypeStrategy.MAX_OVER_ALL,  # default
+    top_k=3,
+    tau=0.1,
+)
 store.add(model, "skill_a:my.intent", ["example 1", "example 2"], k=5)
 store.remove("skill_a:my.intent")
 store.remove_skill("skill_a")
 
-scores = store.scores(query_embedding)  # {label: max_cosine_sim}
+scores = store.scores(query_embedding)  # {label: score}
 ```
 
-Inference: for each label, the maximum cosine similarity across all of its stored prototype embeddings is the match score. Labels are sorted by this score descending.
+The scoring algorithm — and therefore what `scores()` returns — is determined by the `strategy` kwarg. The default `MAX_OVER_ALL` returns the maximum cosine similarity across all stored anchors per label, which is byte-compatible with the store's behaviour before strategies were introduced.
 
-The store can optionally be persisted:
+The store can optionally be persisted and reloaded with any strategy:
 
 ```python
 store.save("prototypes.npz")
-store = PrototypeIntentStore.load("prototypes.npz")
+store = PrototypeIntentStore.load(
+    "prototypes.npz",
+    strategy=PrototypeStrategy.SOFTMAX_WEIGHTED,
+    top_k=3,
+    tau=0.05,
+)
 ```
+
+See [Configuration — Prototype Strategies](configuration.md#prototype-strategies-prototype-mode-only) for a full description of each strategy.
 
 ---
 

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -1,0 +1,58 @@
+# Prototype Strategies
+
+`PrototypeStrategy` (`ovos_m2v_pipeline/strategies.py:51`) is a `str`-enum that controls how a label's training-time embeddings are compressed into stored anchors and how those anchors are turned into a match score at inference time.
+
+The strategy is selected via the `prototype_strategy` config key (default `"max_over_all"`) — see [Configuration](configuration.md#prototype-strategies-prototype-mode-only).
+
+## How strategies work
+
+Every strategy defines two phases:
+
+- **Storage** (`select_anchors` — `ovos_m2v_pipeline/strategies.py:131`) — runs at `PrototypeIntentStore.add()` time. Decides which subset or aggregation of the sample embeddings is persisted as *anchors* for the label.
+- **Scoring** (`score_labels` — `ovos_m2v_pipeline/strategies.py:183`) — runs at inference time. Takes the query embedding and the stored anchors and returns one `float` score per label.
+
+Both functions accept L2-normalised input and return L2-normalised output / scores.
+
+## Strategy reference
+
+| Value | Anchors stored | Score per label |
+|-------|---------------|-----------------|
+| `max_over_all` | Up to `prototype_k` samples (random subsample when `n > k`) | Max cosine over anchors |
+| `mean_centroid` | 1 — mean of all samples, re-normalised | Cosine to centroid |
+| `medoid` | 1 — sample closest to centroid | Cosine to medoid |
+| `top_k_mean` | All samples | Mean of top-`prototype_top_k` cosines |
+| `farthest_point` | Up to `prototype_k` samples via maximin (farthest-point) sampling | Max cosine |
+| `kmeans_centers` | Up to `prototype_k` spherical k-means centroids | Max cosine |
+| `softmax_weighted` | All samples | Softmax-weighted average; temperature = `prototype_tau` |
+
+### Notes
+
+- `max_over_all` is the default. It is byte-compatible with the store's behaviour before strategies were introduced — existing `.npz` files and tuned confidence thresholds remain valid.
+- `mean_centroid` and `medoid` always store exactly one anchor per label, making them cheapest at inference time.
+- `top_k_mean` and `softmax_weighted` keep every sample, so memory cost scales with corpus size; both do their aggregation at score time.
+- `farthest_point` and `kmeans_centers` cluster examples to span the label's semantic space — useful when a skill's intent file contains phrasings from distinct semantic clusters.
+- For `softmax_weighted`, lower `prototype_tau` values make the score approximate the maximum cosine; higher values approach the mean cosine.
+
+## Direct API
+
+The two helpers can also be called directly, independently of `PrototypeIntentStore`:
+
+```python
+import numpy as np
+from ovos_m2v_pipeline.strategies import PrototypeStrategy, select_anchors, score_labels
+
+# select_anchors: storage phase
+anchors = select_anchors(embeddings, PrototypeStrategy.KMEANS_CENTERS, k=4)
+
+# score_labels: scoring phase
+scores = score_labels(
+    query,
+    all_anchors,
+    all_labels,
+    PrototypeStrategy.SOFTMAX_WEIGHTED,
+    top_k=3,
+    tau=0.05,
+)
+```
+
+Both functions accept and return `np.ndarray` with `float32` values. `embeddings` / `query` are assumed to be L2-normalised on input.

--- a/ovos_m2v_pipeline/__init__.py
+++ b/ovos_m2v_pipeline/__init__.py
@@ -12,6 +12,12 @@ from ovos_utils.bracket_expansion import expand_template
 from ovos_utils.fakebus import FakeBus
 from ovos_utils.log import LOG
 
+from ovos_m2v_pipeline.strategies import (
+    PrototypeStrategy,
+    select_anchors,
+    score_labels,
+)
+
 # Labels that bypass the registered-intent check and are always matched
 _SPECIAL_LABELS = {"ocp:play", "common_query:common_query", "stop:stop"}
 
@@ -51,7 +57,14 @@ class PrototypeIntentStore:
         self,
         embeddings: Optional[np.ndarray] = None,
         labels: Optional[np.ndarray] = None,
+        *,
+        strategy: PrototypeStrategy = PrototypeStrategy.MAX_OVER_ALL,
+        top_k: int = 3,
+        tau: float = 0.1,
     ) -> None:
+        self.strategy: PrototypeStrategy = PrototypeStrategy(strategy)
+        self.top_k: int = top_k
+        self.tau: float = tau
         if embeddings is not None and len(embeddings):
             embeddings = np.atleast_2d(embeddings)
             labels_arr = np.asarray(labels, dtype=object)
@@ -107,25 +120,27 @@ class PrototypeIntentStore:
         if not sentences:
             return 0
         self.remove(label)
-        rng = np.random.default_rng(random_state)
-        chosen = (
-            rng.choice(sentences, k, replace=False).tolist()
-            if len(sentences) > k
-            else sentences
-        )
-        embs = np.atleast_2d(model.encode(chosen)).astype(np.float32)
+        # Embed every sample first; the strategy decides which / how many
+        # to keep as anchors at storage time.
+        embs = np.atleast_2d(model.encode(list(sentences))).astype(np.float32)
         norms = np.linalg.norm(embs, axis=1, keepdims=True)
         embs = np.where(norms > 0, embs / norms, embs)
+        anchors = select_anchors(
+            embs, self.strategy, k=k, random_state=random_state,
+        ).astype(np.float32)
+        n_added = len(anchors)
+        if n_added == 0:
+            return 0
 
         if not len(self):
-            self._embeddings = embs
-            self._labels = np.array([label] * len(chosen), dtype=object)
+            self._embeddings = anchors
+            self._labels = np.array([label] * n_added, dtype=object)
         else:
-            self._embeddings = np.vstack([self._embeddings, embs])
+            self._embeddings = np.vstack([self._embeddings, anchors])
             self._labels = np.concatenate(
-                [self._labels, np.array([label] * len(chosen), dtype=object)]
+                [self._labels, np.array([label] * n_added, dtype=object)]
             )
-        return len(chosen)
+        return n_added
 
     def remove(self, label: str) -> None:
         """Remove all prototypes for *label*."""
@@ -162,13 +177,10 @@ class PrototypeIntentStore:
         norm = np.linalg.norm(q)
         if norm > 0:
             q = q / norm
-        sims = self._embeddings @ q  # (n_prototypes,)
-        label_scores: Dict[str, float] = {}
-        for lbl, sim in zip(self._labels, sims):
-            lbl = str(lbl)
-            if lbl not in label_scores or sim > label_scores[lbl]:
-                label_scores[lbl] = float(sim)
-        return label_scores
+        return score_labels(
+            q, self._embeddings, self._labels,
+            self.strategy, top_k=self.top_k, tau=self.tau,
+        )
 
     # ------------------------------------------------------------------
     # Bulk construction helpers (offline / testing)
@@ -182,9 +194,13 @@ class PrototypeIntentStore:
         labels: List[str],
         k: int = 5,
         random_state: int = 42,
+        *,
+        strategy: PrototypeStrategy = PrototypeStrategy.MAX_OVER_ALL,
+        top_k: int = 3,
+        tau: float = 0.1,
     ) -> "PrototypeIntentStore":
         """Build a store from parallel *sentences* / *labels* lists."""
-        store = cls()
+        store = cls(strategy=strategy, top_k=top_k, tau=tau)
         label_to_sentences: Dict[str, List[str]] = {}
         for sent, lbl in zip(sentences, labels):
             label_to_sentences.setdefault(lbl, []).append(sent)
@@ -205,10 +221,20 @@ class PrototypeIntentStore:
         )
 
     @classmethod
-    def load(cls, path: str) -> "PrototypeIntentStore":
+    def load(
+        cls,
+        path: str,
+        *,
+        strategy: PrototypeStrategy = PrototypeStrategy.MAX_OVER_ALL,
+        top_k: int = 3,
+        tau: float = 0.1,
+    ) -> "PrototypeIntentStore":
         """Load from a NumPy ``.npz`` archive."""
         data = np.load(path, allow_pickle=False)
-        return cls(data["embeddings"].astype(np.float32), data["labels"])
+        return cls(
+            data["embeddings"].astype(np.float32), data["labels"],
+            strategy=strategy, top_k=top_k, tau=tau,
+        )
 
 
 def _parse_intent_file(path: str) -> List[str]:
@@ -254,7 +280,16 @@ class Model2VecIntentPipeline(ConfidenceMatcherPipeline):
     Configuration keys (prototype mode)
     ------------------------------------
     ``prototype_k`` : int, default 5
-        Maximum number of prototype embeddings kept per label.
+        Maximum number of prototype embeddings kept per label (used by the
+        strategies that subsample / cluster — see ``prototype_strategy``).
+    ``prototype_strategy`` : str, default ``"max_over_all"``
+        One of the ``PrototypeStrategy`` values
+        (``mean_centroid`` / ``medoid`` / ``max_over_all`` / ``top_k_mean`` /
+        ``farthest_point`` / ``kmeans_centers`` / ``softmax_weighted``).
+    ``prototype_top_k`` : int, default 3
+        K for ``top_k_mean``.
+    ``prototype_tau`` : float, default 0.1
+        Softmax temperature for ``softmax_weighted``.
     """
 
     def __init__(self, bus: Optional[Union[MessageBusClient, FakeBus]] = None,
@@ -275,8 +310,18 @@ class Model2VecIntentPipeline(ConfidenceMatcherPipeline):
             from model2vec import StaticModel
 
             self.model = StaticModel.from_pretrained(model_path)
-            self.prototype_store: Optional[PrototypeIntentStore] = PrototypeIntentStore()
             self._prototype_k: int = self.config.get("prototype_k", 5)
+            self._prototype_strategy: PrototypeStrategy = PrototypeStrategy(
+                self.config.get("prototype_strategy",
+                                PrototypeStrategy.MAX_OVER_ALL.value)
+            )
+            self._prototype_top_k: int = self.config.get("prototype_top_k", 3)
+            self._prototype_tau: float = self.config.get("prototype_tau", 0.1)
+            self.prototype_store: Optional[PrototypeIntentStore] = PrototypeIntentStore(
+                strategy=self._prototype_strategy,
+                top_k=self._prototype_top_k,
+                tau=self._prototype_tau,
+            )
 
             self.bus.on("mycroft.ready", self._handle_ready_prototype)
             self.bus.on("padatious:register_intent", self._handle_register_padatious)

--- a/ovos_m2v_pipeline/strategies.py
+++ b/ovos_m2v_pipeline/strategies.py
@@ -1,0 +1,231 @@
+"""Prototype-scoring strategies for ``PrototypeIntentStore``.
+
+Each strategy decides two things:
+
+1. **Storage**: which subset / aggregation of a label's sample embeddings
+   gets stored as that label's *anchors* at ``add()`` time
+   (``select_anchors``).
+2. **Scoring**: how a query embedding is turned into one similarity score
+   per label at ``scores()`` time (``score_labels``).
+
+Strategies
+----------
+``mean_centroid``
+    One anchor = mean of the per-sample embeddings. ``scores`` = cosine to
+    that single centroid. Cheapest storage and inference. The classic
+    prototype baseline.
+
+``medoid``
+    One anchor = the sample closest to the centroid. Robust to outliers
+    when the per-label samples are noisy, no averaging blur.
+
+``max_over_all``
+    Every sample (up to ``k``) is kept as its own anchor. Score = max
+    cosine over those anchors. Sharpest decision boundary; this is the
+    classic *k-nearest-prototype* matcher and matches the pre-strategy
+    behaviour of this store (the default).
+
+``top_k_mean``
+    All samples are kept; per label, score = mean of the top ``top_k``
+    cosines. Combines the sharpness of max-over-all with smoothing.
+
+``farthest_point``
+    ``k`` samples per label chosen via maximin (farthest-point sampling)
+    so the anchors span the example space. Score = max cosine.
+
+``kmeans_centers``
+    ``k`` spherical-k-means centroids per label. Score = max cosine.
+    Useful when a label has multi-modal phrasings.
+
+``softmax_weighted``
+    All samples kept; per label, score = softmax-weighted average of all
+    cosines. Temperature ``tau`` controls sharpness (low = max-like,
+    high = mean-like).
+"""
+from __future__ import annotations
+
+import enum
+from typing import Iterable
+
+import numpy as np
+
+
+class PrototypeStrategy(str, enum.Enum):
+    """How a label's sample embeddings are aggregated into a match score."""
+
+    MEAN_CENTROID    = "mean_centroid"
+    MEDOID           = "medoid"
+    MAX_OVER_ALL     = "max_over_all"
+    TOP_K_MEAN       = "top_k_mean"
+    FARTHEST_POINT   = "farthest_point"
+    KMEANS_CENTERS   = "kmeans_centers"
+    SOFTMAX_WEIGHTED = "softmax_weighted"
+
+
+#: Strategies whose ``scores()`` step is a plain per-label max-cosine over
+#: the stored anchors. ``select_anchors`` did all the work at ``add()`` time.
+_ANCHOR_BASED = {
+    PrototypeStrategy.MEAN_CENTROID,
+    PrototypeStrategy.MEDOID,
+    PrototypeStrategy.MAX_OVER_ALL,
+    PrototypeStrategy.FARTHEST_POINT,
+    PrototypeStrategy.KMEANS_CENTERS,
+}
+
+
+def _l2_normalize(x: np.ndarray) -> np.ndarray:
+    if x.ndim == 1:
+        norm = np.linalg.norm(x)
+        return x / norm if norm > 0 else x
+    norms = np.linalg.norm(x, axis=1, keepdims=True)
+    return np.where(norms > 0, x / norms, x)
+
+
+def _farthest_point_indices(embs: np.ndarray, k: int) -> list[int]:
+    n = len(embs)
+    if k >= n:
+        return list(range(n))
+    centroid = _l2_normalize(embs.mean(0))
+    seed = int(np.argmax(embs @ centroid))
+    chosen = [seed]
+    dists = np.clip(1.0 - embs @ embs[seed], 0.0, None)
+    for _ in range(k - 1):
+        nxt = int(np.argmax(dists))
+        chosen.append(nxt)
+        dists = np.minimum(dists, np.clip(1.0 - embs @ embs[nxt], 0.0, None))
+    return chosen
+
+
+def _kmeans_centers(embs: np.ndarray, k: int, seed: int = 0,
+                    max_iter: int = 20) -> np.ndarray:
+    """Tiny spherical k-means; assumes ``embs`` is L2-normalised."""
+    n = len(embs)
+    if k >= n:
+        return embs.copy()
+    rng = np.random.default_rng(seed)
+    # k-means++ init
+    centres_idx = [int(rng.integers(n))]
+    while len(centres_idx) < k:
+        dists = np.clip(1.0 - embs @ embs[centres_idx].T, 0.0, None)
+        min_d = dists.min(axis=1)
+        total = float(min_d.sum())
+        if total <= 1e-12:
+            remaining = [i for i in range(n) if i not in centres_idx]
+            if not remaining:
+                break
+            centres_idx.append(int(rng.choice(remaining)))
+            continue
+        centres_idx.append(int(rng.choice(n, p=min_d / total)))
+    centres = embs[centres_idx].copy()
+    for _ in range(max_iter):
+        assignments = np.argmax(embs @ centres.T, axis=1)
+        new_centres = np.zeros_like(centres)
+        for c in range(len(centres)):
+            mask = assignments == c
+            new_centres[c] = embs[mask].mean(0) if mask.any() else centres[c]
+        new_centres = _l2_normalize(new_centres)
+        if np.allclose(centres, new_centres, atol=1e-6):
+            break
+        centres = new_centres
+    return centres
+
+
+def select_anchors(
+    embeddings: np.ndarray,
+    strategy: PrototypeStrategy,
+    k: int = 5,
+    random_state: int = 42,
+) -> np.ndarray:
+    """Return the L2-normalised anchors that ``scores()`` will consume.
+
+    Input ``embeddings`` are assumed L2-normalised. Output is also
+    L2-normalised. The number of returned rows depends on the strategy:
+
+    ============================  ==============================
+    strategy                      anchor count
+    ============================  ==============================
+    MEAN_CENTROID                 1
+    MEDOID                        1
+    MAX_OVER_ALL                  min(k, n)   (random subsample)
+    TOP_K_MEAN, SOFTMAX_WEIGHTED  n           (all samples kept)
+    FARTHEST_POINT, KMEANS_CENTERS min(k, n)
+    ============================  ==============================
+    """
+    n = len(embeddings)
+    if n == 0:
+        return embeddings
+    strategy = PrototypeStrategy(strategy)
+
+    if strategy is PrototypeStrategy.MEAN_CENTROID:
+        return _l2_normalize(embeddings.mean(0)).reshape(1, -1)
+
+    if strategy is PrototypeStrategy.MEDOID:
+        centroid = _l2_normalize(embeddings.mean(0))
+        return embeddings[int(np.argmax(embeddings @ centroid))].reshape(1, -1)
+
+    if strategy is PrototypeStrategy.MAX_OVER_ALL:
+        if n > k:
+            rng = np.random.default_rng(random_state)
+            idx = rng.choice(n, size=k, replace=False)
+            return embeddings[idx]
+        return embeddings
+
+    if strategy is PrototypeStrategy.FARTHEST_POINT:
+        idx = _farthest_point_indices(embeddings, k)
+        return embeddings[idx]
+
+    if strategy is PrototypeStrategy.KMEANS_CENTERS:
+        return _kmeans_centers(embeddings, k, seed=random_state)
+
+    # TOP_K_MEAN / SOFTMAX_WEIGHTED keep all samples — aggregation
+    # happens at score-time, not at storage-time.
+    return embeddings
+
+
+def score_labels(
+    query: np.ndarray,
+    embeddings: np.ndarray,
+    labels: np.ndarray,
+    strategy: PrototypeStrategy,
+    top_k: int = 3,
+    tau: float = 0.1,
+) -> dict[str, float]:
+    """Return ``{label: score}`` for *query* given the stored anchors.
+
+    Query is assumed L2-normalised. ``embeddings`` and ``labels`` are
+    parallel arrays — one row per anchor.
+    """
+    if len(embeddings) == 0:
+        return {}
+    strategy = PrototypeStrategy(strategy)
+    sims = embeddings @ query  # (n_anchors,)
+
+    if strategy in _ANCHOR_BASED:
+        out: dict[str, float] = {}
+        for lbl, s in zip(labels, sims):
+            lbl = str(lbl)
+            if lbl not in out or s > out[lbl]:
+                out[lbl] = float(s)
+        return out
+
+    # Sample-based strategies: group sims by label, then aggregate.
+    by_label: dict[str, list[float]] = {}
+    for lbl, s in zip(labels, sims):
+        by_label.setdefault(str(lbl), []).append(float(s))
+
+    if strategy is PrototypeStrategy.TOP_K_MEAN:
+        return {
+            l: float(np.sort(np.asarray(v))[-min(top_k, len(v)):].mean())
+            for l, v in by_label.items()
+        }
+
+    if strategy is PrototypeStrategy.SOFTMAX_WEIGHTED:
+        out2: dict[str, float] = {}
+        for l, v in by_label.items():
+            arr = np.asarray(v)
+            w = np.exp(arr / tau)
+            w /= w.sum() + 1e-12
+            out2[l] = float((w * arr).sum())
+        return out2
+
+    raise ValueError(f"unknown strategy: {strategy}")

--- a/ovos_m2v_pipeline/strategies.py
+++ b/ovos_m2v_pipeline/strategies.py
@@ -45,8 +45,6 @@ Strategies
 from __future__ import annotations
 
 import enum
-from typing import Iterable
-
 import numpy as np
 
 
@@ -215,17 +213,17 @@ def score_labels(
 
     if strategy is PrototypeStrategy.TOP_K_MEAN:
         return {
-            l: float(np.sort(np.asarray(v))[-min(top_k, len(v)):].mean())
-            for l, v in by_label.items()
+            lbl: float(np.sort(np.asarray(v))[-min(top_k, len(v)):].mean())
+            for lbl, v in by_label.items()
         }
 
     if strategy is PrototypeStrategy.SOFTMAX_WEIGHTED:
         out2: dict[str, float] = {}
-        for l, v in by_label.items():
+        for lbl, v in by_label.items():
             arr = np.asarray(v)
             w = np.exp(arr / tau)
             w /= w.sum() + 1e-12
-            out2[l] = float((w * arr).sum())
+            out2[lbl] = float((w * arr).sum())
         return out2
 
     raise ValueError(f"unknown strategy: {strategy}")

--- a/tests/test_ovoscope_prototype_e2e.py
+++ b/tests/test_ovoscope_prototype_e2e.py
@@ -285,5 +285,144 @@ class TestPrototypeSpecialLabelGating(_PrototypeE2EBase):
         self.assertEqual(msg.msg_type, "common_query.question")
 
 
+class TestPrototypeStrategyE2E(_PrototypeE2EBase):
+    """End-to-end coverage of every ``PrototypeStrategy`` through the bus.
+
+    Each test swaps a freshly-configured ``PrototypeIntentStore`` onto the
+    already-running pipeline so we don't pay MiniCroft startup per strategy.
+    The mock encoder returns the same orthogonal direction for any sentence
+    containing a given keyword, so:
+
+    * MEAN_CENTROID / MEDOID collapse N identical samples → 1 anchor.
+    * MAX_OVER_ALL / FARTHEST_POINT / KMEANS_CENTERS keep up to ``k`` samples.
+    * TOP_K_MEAN / SOFTMAX_WEIGHTED keep every sample.
+    """
+
+    def _reset_with(self, strategy, *, k=5, top_k=3, tau=0.1):
+        from ovos_m2v_pipeline import PrototypeIntentStore
+        self.pipeline.prototype_store = PrototypeIntentStore(
+            strategy=strategy, top_k=top_k, tau=tau,
+        )
+        self.pipeline._prototype_k = k
+        self.pipeline.intents = set()
+        self.pipeline.ignore_labels = []
+
+    def test_every_strategy_dispatches_correct_intent(self):
+        from ovos_m2v_pipeline.strategies import PrototypeStrategy
+        for strat in PrototypeStrategy:
+            with self.subTest(strategy=strat.value):
+                self._reset_with(strat)
+                self._register_padatious(
+                    "skill_a:lights.intent",
+                    ["lights on", "turn on lights", "switch lights on"],
+                )
+                self._register_padatious(
+                    "skill_b:music.intent",
+                    ["play music", "start the music", "music please"],
+                )
+                msg = self._send_and_capture(
+                    "lights on now",
+                    expected_types=["skill_a:lights.intent"],
+                )
+                self.assertIsNotNone(msg, f"{strat.value}: no dispatch")
+                self.assertEqual(msg.msg_type, "skill_a:lights.intent")
+
+    def test_mean_centroid_collapses_samples_to_one_anchor(self):
+        from ovos_m2v_pipeline.strategies import PrototypeStrategy
+        self._reset_with(PrototypeStrategy.MEAN_CENTROID)
+        self._register_padatious(
+            "skill_a:lights.intent",
+            ["lights on", "lights off", "switch the lights"],
+        )
+        labels = list(self.pipeline.prototype_store.labels)
+        self.assertEqual(labels.count("skill_a:lights.intent"), 1)
+
+    def test_medoid_collapses_samples_to_one_anchor(self):
+        from ovos_m2v_pipeline.strategies import PrototypeStrategy
+        self._reset_with(PrototypeStrategy.MEDOID)
+        self._register_padatious(
+            "skill_a:lights.intent",
+            ["lights on", "lights off", "switch the lights"],
+        )
+        labels = list(self.pipeline.prototype_store.labels)
+        self.assertEqual(labels.count("skill_a:lights.intent"), 1)
+
+    def test_max_over_all_keeps_all_samples_up_to_k(self):
+        from ovos_m2v_pipeline.strategies import PrototypeStrategy
+        self._reset_with(PrototypeStrategy.MAX_OVER_ALL, k=5)
+        samples = ["lights on", "lights off", "switch lights"]
+        self._register_padatious("skill_a:lights.intent", samples)
+        labels = list(self.pipeline.prototype_store.labels)
+        self.assertEqual(labels.count("skill_a:lights.intent"), len(samples))
+
+    def test_top_k_mean_keeps_all_samples(self):
+        from ovos_m2v_pipeline.strategies import PrototypeStrategy
+        self._reset_with(PrototypeStrategy.TOP_K_MEAN, top_k=2)
+        samples = ["lights on", "lights off", "switch lights", "lights please"]
+        self._register_padatious("skill_a:lights.intent", samples)
+        labels = list(self.pipeline.prototype_store.labels)
+        # All samples kept; aggregation happens at score-time.
+        self.assertEqual(labels.count("skill_a:lights.intent"), len(samples))
+
+    def test_softmax_weighted_low_tau_picks_max_intent(self):
+        from ovos_m2v_pipeline.strategies import PrototypeStrategy
+        self._reset_with(PrototypeStrategy.SOFTMAX_WEIGHTED, tau=0.01)
+        self._register_padatious("skill_a:lights.intent", ["lights on"])
+        self._register_padatious("skill_b:music.intent", ["play music"])
+        msg = self._send_and_capture(
+            "lights on now",
+            expected_types=["skill_a:lights.intent"],
+        )
+        self.assertIsNotNone(msg)
+        self.assertEqual(msg.msg_type, "skill_a:lights.intent")
+
+
+class TestPrototypeStrategyConfigPlumbing(unittest.TestCase):
+    """The ``prototype_strategy`` / ``prototype_top_k`` / ``prototype_tau``
+    config keys must reach the underlying ``PrototypeIntentStore``."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls._mock_model = MagicMock()
+        cls._mock_model.encode.side_effect = _fake_encode
+        fake_m2v = MagicMock()
+        fake_m2v.StaticModel.from_pretrained.return_value = cls._mock_model
+        cls._patch = patch.dict(sys.modules, {"model2vec": fake_m2v})
+        cls._patch.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._patch.stop()
+
+    def _build(self, **overrides):
+        cfg = {"model": "fake-model", **overrides}
+        return Model2VecPrototypePipeline(bus=None, config=cfg)
+
+    def test_default_strategy_is_max_over_all(self):
+        from ovos_m2v_pipeline.strategies import PrototypeStrategy
+        pipe = self._build()
+        self.assertIs(pipe.prototype_store.strategy, PrototypeStrategy.MAX_OVER_ALL)
+
+    def test_custom_strategy_lands_on_store(self):
+        from ovos_m2v_pipeline.strategies import PrototypeStrategy
+        pipe = self._build(
+            prototype_strategy="softmax_weighted",
+            prototype_top_k=7,
+            prototype_tau=0.25,
+        )
+        self.assertIs(pipe.prototype_store.strategy, PrototypeStrategy.SOFTMAX_WEIGHTED)
+        self.assertEqual(pipe.prototype_store.top_k, 7)
+        self.assertAlmostEqual(pipe.prototype_store.tau, 0.25)
+
+    def test_each_strategy_name_resolves(self):
+        from ovos_m2v_pipeline.strategies import PrototypeStrategy
+        for strat in PrototypeStrategy:
+            pipe = self._build(prototype_strategy=strat.value)
+            self.assertIs(
+                pipe.prototype_store.strategy, strat,
+                f"config '{strat.value}' did not reach the store",
+            )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -1,0 +1,154 @@
+"""Unit tests for ``ovos_m2v_pipeline.strategies``."""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from ovos_m2v_pipeline import PrototypeIntentStore
+from ovos_m2v_pipeline.strategies import (
+    PrototypeStrategy,
+    score_labels,
+    select_anchors,
+)
+
+ALL_STRATEGIES = list(PrototypeStrategy)
+
+
+class _FakeModel:
+    """Deterministic encoder: each sentence → hash-derived embedding."""
+
+    def __init__(self, dim: int = 16):
+        self.dim = dim
+
+    def encode(self, sentences):
+        out = []
+        for s in sentences:
+            rng = np.random.default_rng(abs(hash(s)) % (2**32))
+            v = rng.standard_normal(self.dim).astype(np.float32)
+            out.append(v)
+        return np.asarray(out)
+
+
+def _l2(x):
+    return x / (np.linalg.norm(x, axis=-1, keepdims=True) + 1e-12)
+
+
+# ---------------------------------------------------------------------------
+# select_anchors: anchor counts
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("strategy,expected", [
+    (PrototypeStrategy.MEAN_CENTROID, 1),
+    (PrototypeStrategy.MEDOID, 1),
+    (PrototypeStrategy.MAX_OVER_ALL, 5),       # capped at k
+    (PrototypeStrategy.FARTHEST_POINT, 5),
+    (PrototypeStrategy.KMEANS_CENTERS, 5),
+    (PrototypeStrategy.TOP_K_MEAN, 12),        # keep all samples
+    (PrototypeStrategy.SOFTMAX_WEIGHTED, 12),
+])
+def test_select_anchors_counts(strategy, expected):
+    rng = np.random.default_rng(0)
+    embs = _l2(rng.standard_normal((12, 16)).astype(np.float32))
+    out = select_anchors(embs, strategy, k=5)
+    assert len(out) == expected
+
+
+def test_select_anchors_returns_normalised():
+    rng = np.random.default_rng(1)
+    embs = _l2(rng.standard_normal((20, 8)).astype(np.float32))
+    for s in ALL_STRATEGIES:
+        out = select_anchors(embs, s, k=4)
+        norms = np.linalg.norm(out, axis=1)
+        assert np.allclose(norms, 1.0, atol=1e-5), f"{s} produced non-unit anchors"
+
+
+def test_select_anchors_empty():
+    embs = np.empty((0, 8), dtype=np.float32)
+    for s in ALL_STRATEGIES:
+        assert len(select_anchors(embs, s, k=5)) == 0
+
+
+# ---------------------------------------------------------------------------
+# score_labels: each strategy returns one score per label
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("strategy", ALL_STRATEGIES)
+def test_score_labels_one_per_label(strategy):
+    rng = np.random.default_rng(2)
+    embs = _l2(rng.standard_normal((30, 8)).astype(np.float32))
+    labels = np.array(["a"] * 10 + ["b"] * 10 + ["c"] * 10, dtype=object)
+    q = _l2(rng.standard_normal(8).astype(np.float32))
+    out = score_labels(q, embs, labels, strategy)
+    assert set(out) == {"a", "b", "c"}
+    for v in out.values():
+        assert -1.0001 <= v <= 1.0001
+
+
+def test_score_labels_max_over_all_matches_naive():
+    rng = np.random.default_rng(3)
+    embs = _l2(rng.standard_normal((20, 8)).astype(np.float32))
+    labels = np.array(["a"] * 10 + ["b"] * 10, dtype=object)
+    q = _l2(rng.standard_normal(8).astype(np.float32))
+    out = score_labels(q, embs, labels, PrototypeStrategy.MAX_OVER_ALL)
+    sims = embs @ q
+    assert out["a"] == pytest.approx(float(sims[:10].max()))
+    assert out["b"] == pytest.approx(float(sims[10:].max()))
+
+
+def test_score_labels_top_k_mean_bounded_by_max():
+    rng = np.random.default_rng(4)
+    embs = _l2(rng.standard_normal((10, 8)).astype(np.float32))
+    labels = np.array(["x"] * 10, dtype=object)
+    q = _l2(rng.standard_normal(8).astype(np.float32))
+    max_s = score_labels(q, embs, labels, PrototypeStrategy.MAX_OVER_ALL)["x"]
+    topk = score_labels(q, embs, labels, PrototypeStrategy.TOP_K_MEAN, top_k=3)["x"]
+    assert topk <= max_s + 1e-6
+
+
+def test_score_labels_softmax_low_tau_approaches_max():
+    rng = np.random.default_rng(5)
+    embs = _l2(rng.standard_normal((20, 8)).astype(np.float32))
+    labels = np.array(["x"] * 20, dtype=object)
+    q = _l2(rng.standard_normal(8).astype(np.float32))
+    max_s = score_labels(q, embs, labels, PrototypeStrategy.MAX_OVER_ALL)["x"]
+    soft = score_labels(q, embs, labels, PrototypeStrategy.SOFTMAX_WEIGHTED, tau=0.01)["x"]
+    assert abs(soft - max_s) < 0.05
+
+
+def test_score_labels_empty():
+    embs = np.empty((0, 8), dtype=np.float32)
+    labels = np.array([], dtype=object)
+    q = np.zeros(8, dtype=np.float32)
+    for s in ALL_STRATEGIES:
+        assert score_labels(q, embs, labels, s) == {}
+
+
+# ---------------------------------------------------------------------------
+# PrototypeIntentStore end-to-end with each strategy
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("strategy", ALL_STRATEGIES)
+def test_store_add_and_score_each_strategy(strategy):
+    model = _FakeModel()
+    store = PrototypeIntentStore(strategy=strategy, top_k=2, tau=0.1)
+    store.add(model, "weather", [f"weather example {i}" for i in range(10)], k=5)
+    store.add(model, "music",   [f"music example {i}"   for i in range(10)], k=5)
+    assert set(store.unique_labels) == {"weather", "music"}
+    q = model.encode(["weather example 0"])[0]
+    out = store.scores(q)
+    assert set(out) == {"weather", "music"}
+    # The "weather example 0" embedding should rank weather >= music.
+    assert out["weather"] >= out["music"]
+
+
+def test_store_default_strategy_is_max_over_all_backcompat():
+    """The store default preserves pre-strategy behaviour."""
+    store = PrototypeIntentStore()
+    assert store.strategy is PrototypeStrategy.MAX_OVER_ALL
+
+
+def test_store_centroid_collapses_to_one_anchor():
+    model = _FakeModel()
+    store = PrototypeIntentStore(strategy=PrototypeStrategy.MEAN_CENTROID)
+    store.add(model, "lbl", [f"hello {i}" for i in range(10)], k=5)
+    assert len(store) == 1

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -21,9 +21,11 @@ class _FakeModel:
         self.dim = dim
 
     def encode(self, sentences):
+        import hashlib
         out = []
         for s in sentences:
-            rng = np.random.default_rng(abs(hash(s)) % (2**32))
+            seed = int(hashlib.md5(s.encode()).hexdigest(), 16) % (2**32)
+            rng = np.random.default_rng(seed)
             v = rng.standard_normal(self.dim).astype(np.float32)
             out.append(v)
         return np.asarray(out)


### PR DESCRIPTION
## Summary

Adds a strategy enum that controls how a label's sample embeddings are aggregated into a match score in prototype mode. The default (`max_over_all`) preserves the pre-PR scoring behaviour; six new strategies cover the nebulento-style spectrum.

| strategy | what it does |
|---|---|
| `mean_centroid` | 1 anchor = centroid of samples; score = cosine to that centroid |
| `medoid` | 1 anchor = sample closest to centroid; robust to outliers |
| `max_over_all` *(default, back-compat)* | N anchors = all samples; score = max cosine |
| `top_k_mean` | All samples kept; score = mean of top-K cosines per label |
| `farthest_point` | K maximin-selected anchors per label |
| `kmeans_centers` | K spherical-k-means centroids per label |
| `softmax_weighted` | All samples kept; score = softmax-weighted mean cosine (τ) |

## Public API

`PrototypeIntentStore` now accepts:

```python
PrototypeIntentStore(strategy=PrototypeStrategy.MAX_OVER_ALL,  # default = previous behaviour
                     top_k=3, tau=0.1)
```

`add()` and `scores()` are unchanged externally — `add()` routes through `select_anchors()` at storage time, `scores()` routes through `score_labels()` at inference time. Both live in the new `ovos_m2v_pipeline.strategies` module.

`Model2VecIntents` exposes them as config keys:

```yaml
intents:
  ovos_m2v_pipeline:
    mode: prototype
    prototype_strategy: max_over_all     # one of the 7 values above
    prototype_k: 5                        # cap for subsampling / clustering
    prototype_top_k: 3                    # for top_k_mean
    prototype_tau: 0.1                    # for softmax_weighted
```

## Back-compat

- The store default is `MAX_OVER_ALL` with `k=5`, which is byte-for-byte equivalent to the previous behaviour (random subsample → max-cosine). Existing `Model2VecIntents` configs continue to score identically.
- `PrototypeIntentStore()` with no args still produces an empty store with `MAX_OVER_ALL`.
- `.save()` / `.load()` semantics are unchanged; `.load()` gained optional `strategy=` / `top_k=` / `tau=` kwargs so a reloaded store can be re-strategized.

## Tests

`tests/test_strategies.py` covers:

- Anchor counts per strategy (1 / N / K).
- L2-normalisation invariants on the output of `select_anchors()`.
- `score_labels()` returns exactly one score per unique label, bounded to [-1, 1].
- `MAX_OVER_ALL` matches a naive per-label max-cosine.
- `TOP_K_MEAN` is bounded above by `MAX_OVER_ALL`.
- `SOFTMAX_WEIGHTED` with `τ→0` approaches `MAX_OVER_ALL`.
- Empty store behaviour for every strategy.
- End-to-end `PrototypeIntentStore.add()` + `.scores()` round-trip per strategy.
- The default strategy is `MAX_OVER_ALL` (back-compat assertion).

## Why

Several downstream consumers (intent benchmarks, prototype skills with multi-modal phrasings, ASR-noise-resilient deployments) want to swap the aggregation without forking the store. Putting this in the upstream plugin avoids reimplementing the math in every consumer.

## Test plan

- [x] Strategy math hand-verified end-to-end (anchor counts, normalisation, max/topk/softmax bounds, empty stores)
- [x] Default-strategy back-compat asserted in test
- [ ] CI to run the test suite in a clean env (local env has an unrelated `skops`/`deltachat` collection issue that breaks even the existing `test_pipeline.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prototype-based intent matching now supports multiple configurable selection and scoring strategies for enhanced flexibility
  * New configuration options to customize prototype matching behavior and performance

* **Documentation**
  * Updated pipeline configuration documentation with new prototype strategy and tuning parameters

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenVoiceOS/ovos-m2v-pipeline/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->