### PR TITLE
feat: consume OVOS-INTENT-4 template registration (alongside legacy)

### DIFF
--- a/.github/workflows/ovoscope.yml
+++ b/.github/workflows/ovoscope.yml
@@ -1,0 +1,24 @@
+name: E2E Tests (ovoscope)
+
+on:
+  pull_request:
+    branches: [dev]
+    paths:
+      - 'ovos_m2v_pipeline/**'
+      - 'tests/test_ovoscope_e2e.py'
+      - 'tests/test_ovoscope_prototype_e2e.py'
+      - 'tests/end2end/**'
+      - '.github/workflows/ovoscope.yml'
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    uses: OpenVoiceOS/gh-automations/.github/workflows/ovoscope.yml@dev
+    with:
+      install_extras: "test"
+      test_path: "tests/test_ovoscope_prototype_e2e.py tests/end2end/"
+      require_m2v: true
+      # Validate against the unreleased ovoscope dev branch (E2EPipelineHarness)
+      # and the m2v pipeline from dev. Drop once ovoscope is released to PyPI
+      # with the harness.
+      pre_release: true

--- a/ovos_m2v_pipeline/__init__.py
+++ b/ovos_m2v_pipeline/__init__.py
@@ -24,12 +24,6 @@ from ovos_m2v_pipeline.strategies import (
 #: Regex matching ``{slot}`` placeholders in OVOS-INTENT-1 template samples.
 _SLOT_RE = re.compile(r"\{([a-zA-Z_][a-zA-Z0-9_]*)\}")
 
-#: Max number of ``{slot}`` fill combinations generated per template sample
-#: when expanding registered entity values (OVOS-INTENT-4 §7) before
-#: embedding. Bounds the per-intent prototype count for templates with many
-#: slots / large entity vocabularies.
-_ENTITY_EXPANSION_CAP: int = 8
-
 # Labels that bypass the registered-intent check and are always matched
 _SPECIAL_LABELS = {"ocp:play", "common_query:common_query", "stop:stop"}
 
@@ -593,9 +587,9 @@ class Model2VecIntentPipeline(ConfidenceMatcherPipeline):
 
     def _expand_entities(self, samples: List[str]) -> List[str]:
         """Fill ``{slot}`` placeholders in template *samples* with registered
-        entity values (OVOS-INTENT-4 §7), capped per sample. Samples without
-        placeholders, or whose entity is unregistered, are passed through with
-        the placeholder left literal (entities are an optional hint, §7).
+        entity values (OVOS-INTENT-4 §7). Samples without placeholders, or whose
+        entity is unregistered, are passed through with the placeholder left
+        literal (entities are an optional hint, §7).
         """
         if not self.entities:
             return list(samples)
@@ -609,9 +603,7 @@ class Model2VecIntentPipeline(ConfidenceMatcherPipeline):
             for slot in slots:
                 vals = self.entities.get(slot.lower())
                 slot_values.append(vals if vals else ["{" + slot + "}"])
-            for combo in itertools.islice(
-                itertools.product(*slot_values), _ENTITY_EXPANSION_CAP
-            ):
+            for combo in itertools.product(*slot_values):
                 filled = tmpl
                 for slot, val in zip(slots, combo):
                     filled = filled.replace("{" + slot + "}", val, 1)

--- a/ovos_m2v_pipeline/__init__.py
+++ b/ovos_m2v_pipeline/__init__.py
@@ -1,3 +1,5 @@
+import itertools
+import re
 import time
 import numpy as np
 from typing import List, Optional, Union, Dict, Iterable, Tuple
@@ -8,6 +10,7 @@ from ovos_bus_client.message import Message
 from ovos_bus_client.session import SessionManager
 from ovos_config.config import Configuration
 from ovos_plugin_manager.templates.pipeline import IntentHandlerMatch, ConfidenceMatcherPipeline
+from ovos_spec_tools import SpecMessage
 from ovos_utils.bracket_expansion import expand_template
 from ovos_utils.fakebus import FakeBus
 from ovos_utils.log import LOG
@@ -17,6 +20,15 @@ from ovos_m2v_pipeline.strategies import (
     select_anchors,
     score_labels,
 )
+
+#: Regex matching ``{slot}`` placeholders in OVOS-INTENT-1 template samples.
+_SLOT_RE = re.compile(r"\{([a-zA-Z_][a-zA-Z0-9_]*)\}")
+
+#: Max number of ``{slot}`` fill combinations generated per template sample
+#: when expanding registered entity values (OVOS-INTENT-4 §7) before
+#: embedding. Bounds the per-intent prototype count for templates with many
+#: slots / large entity vocabularies.
+_ENTITY_EXPANSION_CAP: int = 8
 
 # Labels that bypass the registered-intent check and are always matched
 _SPECIAL_LABELS = {"ocp:play", "common_query:common_query", "stop:stop"}
@@ -303,6 +315,10 @@ class Model2VecIntentPipeline(ConfidenceMatcherPipeline):
         self.intents: set = set()
         self.ignore_labels: List[str] = self.config.get("ignore_intents") or []
         self._syncing = False
+        #: Registered entity value-sets (OVOS-INTENT-4 §7), keyed by entity
+        #: name (lowercase). Used to fill ``{slot}`` placeholders in template
+        #: samples before embedding. Disabled (left empty) in classifier mode.
+        self.entities: Dict[str, List[str]] = {}
 
         mode = self.config.get("mode", "classifier")
 
@@ -324,10 +340,16 @@ class Model2VecIntentPipeline(ConfidenceMatcherPipeline):
             )
 
             self.bus.on("mycroft.ready", self._handle_ready_prototype)
+            # Legacy registration topics (kept alongside OVOS-INTENT-4).
             self.bus.on("padatious:register_intent", self._handle_register_padatious)
             self.bus.on("register_intent", self._handle_register_adapt)
             self.bus.on("detach_intent", self._handle_detach_intent)
             self.bus.on("detach_skill", self._handle_detach_skill)
+            # OVOS-INTENT-4 registration topics. m2v matches on example
+            # utterances, so it is a TEMPLATE-style engine: it consumes
+            # `ovos.intent.register.template` (§6) and NOT
+            # `ovos.intent.register.keyword` (§11).
+            self._wire_intent4_handlers()
 
             LOG.info(
                 f"Loaded Model2VecIntents pipeline (prototype mode) "
@@ -344,6 +366,10 @@ class Model2VecIntentPipeline(ConfidenceMatcherPipeline):
             self.bus.on("register_intent", self.handle_sync_intents)
             self.bus.on("detach_intent", self.handle_sync_intents)
             self.bus.on("detach_skill", self.handle_sync_intents)
+            # OVOS-INTENT-4 registration topics. In classifier mode the model
+            # is frozen, so registrations only (de)gate which trained classes
+            # are eligible — exactly like the legacy manifest sync above.
+            self._wire_intent4_handlers()
 
             LOG.info(f"Loaded Model2VecIntents pipeline with model: '{model_path}'")
 
@@ -520,6 +546,195 @@ class Model2VecIntentPipeline(ConfidenceMatcherPipeline):
             self.prototype_store.remove_skill(skill_id)
             self.intents = {i for i in self.intents if not i.startswith(skill_id + ":")}
             LOG.debug(f"Prototype store: removed prototypes for skill '{skill_id}'")
+
+    # ------------------------------------------------------------------
+    # OVOS-INTENT-4 registration (template method) — consumed in addition
+    # to the legacy topics. m2v is a template-style engine (it matches on
+    # example utterances), so it subscribes to `ovos.intent.register.template`
+    # (§6) and `ovos.entity.register` (§7), plus the shared deregister /
+    # enable / disable topics (§8). It deliberately does NOT consume
+    # `ovos.intent.register.keyword` (§11 — keyword engines only).
+    # ------------------------------------------------------------------
+
+    def _wire_intent4_handlers(self) -> None:
+        """Subscribe to the OVOS-INTENT-4 registration topics (§4)."""
+        self.bus.on(SpecMessage.INTENT_REGISTER_TEMPLATE.value,
+                    self._handle_intent4_register_template)
+        self.bus.on(SpecMessage.ENTITY_REGISTER.value,
+                    self._handle_intent4_register_entity)
+        self.bus.on(SpecMessage.INTENT_DEREGISTER.value,
+                    self._handle_intent4_deregister_intent)
+        self.bus.on(SpecMessage.ENTITY_DEREGISTER.value,
+                    self._handle_intent4_deregister_entity)
+        self.bus.on(SpecMessage.SKILL_DEREGISTER.value,
+                    self._handle_intent4_deregister_skill)
+        self.bus.on(SpecMessage.INTENT_ENABLE.value,
+                    self._handle_intent4_enable)
+        self.bus.on(SpecMessage.INTENT_DISABLE.value,
+                    self._handle_intent4_disable)
+
+    @staticmethod
+    def _intent4_label(message: Message) -> str:
+        """Build the internal ``<skill_id>:<intent_name>`` label from §3.2 fields."""
+        skill_id = message.data.get("skill_id") or message.context.get("skill_id", "")
+        intent_name = message.data.get("intent_name", "")
+        if not skill_id or not intent_name:
+            return ""
+        return f"{skill_id}:{intent_name}"
+
+    def _intent4_warn(self, topic: str, message: Message, reason: str) -> None:
+        """Log a malformed-registration rejection at WARN (§5.3 / §6.3 / §7.2)."""
+        LOG.warning(
+            f"rejecting {topic} registration: {reason} "
+            f"[skill_id={message.data.get('skill_id')!r} "
+            f"name={message.data.get('intent_name') or message.data.get('entity_name')!r} "
+            f"lang={message.data.get('lang')!r}]"
+        )
+
+    def _expand_entities(self, samples: List[str]) -> List[str]:
+        """Fill ``{slot}`` placeholders in template *samples* with registered
+        entity values (OVOS-INTENT-4 §7), capped per sample. Samples without
+        placeholders, or whose entity is unregistered, are passed through with
+        the placeholder left literal (entities are an optional hint, §7).
+        """
+        if not self.entities:
+            return list(samples)
+        out: List[str] = []
+        for tmpl in samples:
+            slots = _SLOT_RE.findall(tmpl)
+            if not slots:
+                out.append(tmpl)
+                continue
+            slot_values: List[List[str]] = []
+            for slot in slots:
+                vals = self.entities.get(slot.lower())
+                slot_values.append(vals if vals else ["{" + slot + "}"])
+            for combo in itertools.islice(
+                itertools.product(*slot_values), _ENTITY_EXPANSION_CAP
+            ):
+                filled = tmpl
+                for slot, val in zip(slots, combo):
+                    filled = filled.replace("{" + slot + "}", val, 1)
+                out.append(filled.strip())
+        return out
+
+    def _handle_intent4_register_template(self, message: Message) -> None:
+        """Register a template intent (§6): bracket-expand + entity-fill the
+        ``samples`` and embed them as prototypes (prototype mode) or track the
+        label name (classifier mode)."""
+        topic = SpecMessage.INTENT_REGISTER_TEMPLATE.value
+        label = self._intent4_label(message)
+        if not label:
+            self._intent4_warn(topic, message, "missing skill_id or intent_name")
+            return
+        if label in self.ignore_labels:
+            return
+        samples = message.data.get("samples")
+        if not samples:  # missing or empty -> malformed (§6.3)
+            self._intent4_warn(topic, message, "samples missing or empty")
+            return
+
+        # Classifier mode is frozen: only gate the (already trained) label.
+        if self.prototype_store is None:
+            self.intents.add(label)
+            LOG.debug(f"Model2Vec: tracking INTENT-4 template label '{label}'")
+            return
+
+        expanded: List[str] = []
+        for s in self._expand_entities(list(samples)):
+            try:
+                expanded.extend(expand_template(s))
+            except Exception:
+                expanded.append(s)
+        expanded = [s for s in (e.strip() for e in expanded) if s]
+        if not expanded:  # zero non-empty expansions -> malformed (§6.3)
+            self._intent4_warn(topic, message, "samples expand to zero non-empty templates")
+            return
+        n = self.prototype_store.add(self.model, label, expanded, k=self._prototype_k)
+        self.intents.add(label)
+        LOG.debug(f"Prototype store: added {n} prototype(s) for INTENT-4 template '{label}'")
+
+    def _handle_intent4_register_entity(self, message: Message) -> None:
+        """Register an entity value-set hint (§7). No-op in classifier mode."""
+        topic = SpecMessage.ENTITY_REGISTER.value
+        name: str = message.data.get("entity_name", "")
+        samples = message.data.get("samples")
+        if not name:
+            self._intent4_warn(topic, message, "missing entity_name")
+            return
+        if not samples:  # missing or empty -> malformed (§7.2)
+            self._intent4_warn(topic, message, "samples missing or empty")
+            return
+        if self.prototype_store is None:
+            return  # classifier model is frozen; no slot-fill to perform
+        values: set = set()
+        for s in samples:
+            try:
+                for v in expand_template(s):
+                    v = v.strip()
+                    if v:
+                        values.add(v)
+            except Exception:
+                v = str(s).strip()
+                if v:
+                    values.add(v)
+        self.entities[name.lower()] = list(values)
+        LOG.debug(f"Model2Vec: registered INTENT-4 entity '{name}' ({len(values)} values)")
+
+    def _handle_intent4_deregister_intent(self, message: Message) -> None:
+        """Remove one intent (§8.2)."""
+        label = self._intent4_label(message)
+        if not label:
+            return
+        if self.prototype_store is not None:
+            self.prototype_store.remove(label)
+        self.intents.discard(label)
+        LOG.debug(f"Model2Vec: deregistered INTENT-4 intent '{label}'")
+
+    def _handle_intent4_deregister_entity(self, message: Message) -> None:
+        """Remove one entity (§8.3). No-op in classifier mode."""
+        name: str = message.data.get("entity_name", "")
+        if name:
+            self.entities.pop(name.lower(), None)
+            LOG.debug(f"Model2Vec: deregistered INTENT-4 entity '{name}'")
+
+    def _handle_intent4_deregister_skill(self, message: Message) -> None:
+        """Remove every intent and entity owned by a skill (§8.4)."""
+        skill_id: str = message.data.get("skill_id") or message.context.get("skill_id", "")
+        if not skill_id:
+            return
+        if self.prototype_store is not None:
+            self.prototype_store.remove_skill(skill_id)
+        self.intents = {i for i in self.intents if not i.startswith(skill_id + ":")}
+        LOG.debug(f"Model2Vec: deregistered all INTENT-4 registrations for skill '{skill_id}'")
+
+    def _handle_intent4_disable(self, message: Message) -> None:
+        """Suppress an intent without losing its definition (§8.5).
+
+        m2v keeps no separate enabled/disabled flag; suppression is realised
+        by dropping the label from the match-eligible set (and its prototypes),
+        mirroring deregistration. Re-enabling requires re-registration, which
+        is how skills re-arm intents on this engine.
+        """
+        label = self._intent4_label(message)
+        if not label:
+            return
+        if self.prototype_store is not None:
+            self.prototype_store.remove(label)
+        self.intents.discard(label)
+        LOG.debug(f"Model2Vec: disabled INTENT-4 intent '{label}'")
+
+    def _handle_intent4_enable(self, message: Message) -> None:
+        """Re-arm a previously disabled intent (§8.5).
+
+        In classifier mode the trained class is re-added to the eligible set.
+        In prototype mode the prototypes were dropped on disable and can only
+        be restored by re-registration, so this only restores label tracking.
+        """
+        label = self._intent4_label(message)
+        if label and label not in self.ignore_labels:
+            self.intents.add(label)
+            LOG.debug(f"Model2Vec: enabled INTENT-4 intent '{label}'")
 
     # ------------------------------------------------------------------
     # Matching

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "ovos-bus-client",
     "ovos-config",
     "ovos-utils>=0.3.4,<1.0.0",
-    "ovos-spec-tools>=0.10.0a1",
+    "ovos-spec-tools>=0.11.0a1",
     "model2vec[inference]",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     # opm.pipeline entrypoints + the bus-client 2.x e2e stack need modern opm;
     # the prerelease floor lets the resolver pick it without --pre.
     "ovos-plugin-manager>=2.3.0a1,<3.0.0",
-    "ovos-bus-client>=2.4.0a1",
+    "ovos-bus-client>=2.5.1a1,<3.0.0",
     "ovos-config",
     "ovos-utils>=0.3.4,<1.0.0",
     "ovos-spec-tools>=0.16.1a2",
@@ -36,7 +36,7 @@ test = [
     "numpy",
     # INTENT-4 consumer e2e stack floor (ovos.intent.register.* topics +
     # E2EPipelineHarness namespace flags). Mirrors ovos-test-harness@dev.
-    "ovos-bus-client>=2.4.0a1",
+    "ovos-bus-client>=2.5.1a1,<3.0.0",
     "ovos-spec-tools>=0.16.1a2",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,10 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
 ]
 dependencies = [
-    "ovos-plugin-manager>=0.5.0,<3.0.0",
-    "ovos-bus-client",
+    # opm.pipeline entrypoints + the bus-client 2.x e2e stack need modern opm;
+    # the prerelease floor lets the resolver pick it without --pre.
+    "ovos-plugin-manager>=2.3.0a1,<3.0.0",
+    "ovos-bus-client>=2.4.0a1",
     "ovos-config",
     "ovos-utils>=0.3.4,<1.0.0",
     "ovos-spec-tools>=0.16.1a2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,19 @@ dependencies = [
     "ovos-bus-client",
     "ovos-config",
     "ovos-utils>=0.3.4,<1.0.0",
-    "ovos-spec-tools>=0.11.0a1",
+    "ovos-spec-tools>=0.16.1a2",
     "model2vec[inference]",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "pytest-cov",
+    "numpy",
+    # INTENT-4 consumer e2e stack floor (ovos.intent.register.* topics +
+    # E2EPipelineHarness namespace flags). Mirrors ovos-test-harness@dev.
+    "ovos-bus-client>=2.4.0a1",
+    "ovos-spec-tools>=0.16.1a2",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "ovos-bus-client",
     "ovos-config",
     "ovos-utils>=0.3.4,<1.0.0",
+    "ovos-spec-tools>=0.10.0a1",
     "model2vec[inference]",
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+"""Pytest configuration for the m2v test suite.
+
+``test_live_fixture.py`` skips itself at *module* level via
+``pytest.skip(allow_module_level=True)`` when ``OVOSCOPE_LIVE`` is unset. That
+raises ``Skipped`` (a ``BaseException``) during import, which the ovoscope
+pytest plugin's ``pytest_pycollect_makemodule`` wrapper only guards with
+``except Exception`` — so the Skipped escapes, aborts the whole collection
+session, and pytest reports "found no collectors" for *every* other test file
+(including the ovoscope e2e suites). See the ovoscope plugin bug.
+
+Until that is fixed upstream, ignore the live fixture during ordinary
+(non-OVOSCOPE_LIVE) collection so the rest of the suite — unit tests and the
+ovoscope end-to-end tests — collects normally. The dedicated live-test workflow
+sets ``OVOSCOPE_LIVE=1`` and still collects it.
+"""
+import os
+
+collect_ignore = []
+if os.environ.get("OVOSCOPE_LIVE") != "1":
+    collect_ignore.append("test_live_fixture.py")

--- a/tests/end2end/test_intent4_consume_e2e.py
+++ b/tests/end2end/test_intent4_consume_e2e.py
@@ -1,0 +1,263 @@
+"""OVOS-INTENT-4 *consumer* end-to-end tests for the Model2Vec pipeline.
+
+``tests/test_ovoscope_prototype_e2e.py`` proves the prototype pipeline matches
+intents registered via the legacy ``padatious:register_intent`` event. This
+suite proves m2v *consumes the INTENT-4 spec registration topics*
+(``ovos-intent-4.md``) and then matches.
+
+m2v is a **template** engine: it consumes ``ovos.intent.register.template``
+(§6) and not ``ovos.intent.register.keyword`` (§11). It runs in *prototype*
+mode here (the only mode that ingests fresh samples e2e); ``model2vec.StaticModel``
+is patched at the ``sys.modules`` level with a deterministic, linearly-separable
+mock encoder so no model download is needed and cosine scoring is exact.
+
+Each test emits the spec registration on the wire, sends a matching utterance,
+and asserts the intent dispatches ``<skill_id>:<intent_name>`` — proving
+spec-topic consumption.
+
+DIVERGENCE (real finding, ``test_spec_enable_rearms_intent`` is xfail): in
+prototype mode ``ovos.intent.disable`` drops the label's prototypes, and
+``ovos.intent.enable`` only restores *label tracking* — it cannot re-embed the
+samples, so a disabled-then-enabled intent does NOT match again (re-arming
+requires re-registration). This departs from INTENT-4 §8.5's "re-arm a
+previously disabled intent".
+"""
+import sys
+import threading
+import unittest
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+ovoscope = pytest.importorskip(
+    "ovoscope", reason="ovoscope not installed; skipping E2E tests"
+)
+
+from ovos_bus_client.message import Message  # noqa: E402
+from ovos_bus_client.session import Session  # noqa: E402
+from ovos_config.config import Configuration  # noqa: E402
+from ovos_spec_tools import SpecMessage  # noqa: E402
+from ovoscope import get_minicroft  # noqa: E402
+
+from ovos_m2v_pipeline import Model2VecPrototypePipeline  # noqa: E402
+
+PIPELINE_ID = "ovos-m2v-prototype-pipeline"
+CONFIG_KEY = "ovos_m2v_prototype_pipeline"
+
+REGISTER_TEMPLATE = str(SpecMessage.INTENT_REGISTER_TEMPLATE)
+REGISTER_KEYWORD = str(SpecMessage.INTENT_REGISTER_KEYWORD)
+INTENT_DEREGISTER = str(SpecMessage.INTENT_DEREGISTER)
+SKILL_DEREGISTER = str(SpecMessage.SKILL_DEREGISTER)
+INTENT_DISABLE = str(SpecMessage.INTENT_DISABLE)
+INTENT_ENABLE = str(SpecMessage.INTENT_ENABLE)
+
+SKILL_ID = "intent4_m2v.skill"
+
+# Deterministic orthogonal directions for the mock encoder (cosine 0 between
+# distinct keys, 1.0 for identical inputs).
+_DIRECTIONS = {
+    "lights": np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32),
+    "music":  np.array([0.0, 1.0, 0.0, 0.0], dtype=np.float32),
+}
+_NOISE = np.array([0.0, 0.0, 0.0, 0.0], dtype=np.float32)
+
+
+def _fake_encode(sentences):
+    out = []
+    for s in sentences:
+        sl = s.lower()
+        vec = _NOISE.copy()
+        for key, direction in _DIRECTIONS.items():
+            if key in sl:
+                vec = direction.copy()
+                break
+        out.append(vec)
+    return np.stack(out)
+
+
+class TestIntent4Consume(unittest.TestCase):
+    """OVOS-INTENT-4 consumer assertions for m2v prototype mode."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls._mock_model = MagicMock()
+        cls._mock_model.encode.side_effect = _fake_encode
+        fake_m2v = MagicMock()
+        fake_m2v.StaticModel.from_pretrained.return_value = cls._mock_model
+        cls._sys_modules_patch = patch.dict(sys.modules, {"model2vec": fake_m2v})
+        cls._sys_modules_patch.start()
+
+        cfg = Configuration()
+        intents_cfg = cfg.setdefault("intents", {})
+        cls._orig = intents_cfg.get(CONFIG_KEY)
+        intents_cfg[CONFIG_KEY] = {"model": "fake-model", "prototype_k": 5}
+
+        cls.mc = get_minicroft(skill_ids=[], lang="en-US",
+                               default_pipeline=[PIPELINE_ID], max_wait=60)
+        cls.pipeline: Model2VecPrototypePipeline = (
+            cls.mc.intents.pipeline_plugins[PIPELINE_ID]
+        )
+        cls.pipeline.model = cls._mock_model
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            cls.mc.stop()
+        finally:
+            cfg = Configuration()
+            intents_cfg = cfg.get("intents", {})
+            if cls._orig is None:
+                intents_cfg.pop(CONFIG_KEY, None)
+            else:
+                intents_cfg[CONFIG_KEY] = cls._orig
+            cls._sys_modules_patch.stop()
+
+    def setUp(self):
+        from ovos_m2v_pipeline import PrototypeIntentStore
+        self.pipeline.prototype_store = PrototypeIntentStore()
+        self.pipeline.intents = set()
+        self.pipeline.ignore_labels = []
+
+    # -- helpers --------------------------------------------------------
+
+    def _register_template(self, intent_name, samples, lang="en-US"):
+        self.mc.bus.emit(Message(REGISTER_TEMPLATE, {
+            "skill_id": SKILL_ID, "intent_name": intent_name,
+            "lang": lang, "samples": samples,
+        }, {"skill_id": SKILL_ID}))
+
+    def _emit(self, topic, intent_name=None, **extra):
+        data = {"skill_id": SKILL_ID, "lang": "en-US"}
+        if intent_name is not None:
+            data["intent_name"] = intent_name
+        data.update(extra)
+        self.mc.bus.emit(Message(topic, data, {"skill_id": SKILL_ID}))
+
+    def _utterance(self, utterance):
+        return Message("recognizer_loop:utterance",
+                       {"utterances": [utterance], "lang": "en-US"}, {})
+
+    def _send_and_capture(self, utterance, expected_types, timeout=5.0):
+        got, done, failed = [], threading.Event(), threading.Event()
+
+        def _on_match(msg):
+            got.append(msg)
+            done.set()
+
+        def _on_fail(_msg):
+            failed.set()
+            done.set()
+
+        for t in expected_types:
+            self.mc.bus.on(t, _on_match)
+        self.mc.bus.on("complete_intent_failure", _on_fail)
+        try:
+            self.mc.bus.emit(self._utterance(utterance))
+            done.wait(timeout=timeout)
+        finally:
+            for t in expected_types:
+                self.mc.bus.remove(t, _on_match)
+            self.mc.bus.remove("complete_intent_failure", _on_fail)
+        if failed.is_set() and not got:
+            return None
+        return got[0] if got else None
+
+    def _expect_no_match(self, utterance, timeout=2.0):
+        failed = threading.Event()
+
+        def _on_fail(_msg):
+            failed.set()
+
+        self.mc.bus.on("complete_intent_failure", _on_fail)
+        try:
+            self.mc.bus.emit(self._utterance(utterance))
+            failed.wait(timeout=timeout)
+        finally:
+            self.mc.bus.remove("complete_intent_failure", _on_fail)
+        self.assertTrue(failed.is_set(),
+                        f"Expected no match for {utterance!r}.")
+
+    # -- §6 spec template registration is matchable ---------------------
+
+    def test_spec_template_registration_is_matchable(self):
+        self._register_template("lights", ["turn on the lights", "lights on"])
+        self.assertIn(f"{SKILL_ID}:lights", self.pipeline.intents)
+        msg = self._send_and_capture("lights on now",
+                                     expected_types=[f"{SKILL_ID}:lights"])
+        self.assertIsNotNone(msg, "expected match from spec registration")
+        self.assertEqual(msg.msg_type, f"{SKILL_ID}:lights")
+
+    def test_spec_template_builds_prototypes(self):
+        self._register_template("music", ["play some music", "start the music"])
+        self.assertIn(f"{SKILL_ID}:music",
+                      list(self.pipeline.prototype_store.labels))
+
+    # -- back-compat: legacy registration still matches -----------------
+
+    def test_legacy_registration_still_matches(self):
+        self.mc.bus.emit(Message("padatious:register_intent", {
+            "name": f"{SKILL_ID}:lights",
+            "samples": ["turn on the lights", "lights on"],
+        }, {"skill_id": SKILL_ID}))
+        msg = self._send_and_capture("lights on now",
+                                     expected_types=[f"{SKILL_ID}:lights"])
+        self.assertIsNotNone(msg, "legacy registration must still match")
+
+    # -- §8.2 / §8.4 deregistration -------------------------------------
+
+    def test_spec_deregister_removes_intent(self):
+        self._register_template("lights", ["turn on the lights", "lights on"])
+        self.assertIsNotNone(
+            self._send_and_capture("lights on now",
+                                   expected_types=[f"{SKILL_ID}:lights"]),
+            "sanity: should match before deregister",
+        )
+        self._emit(INTENT_DEREGISTER, "lights")
+        self._expect_no_match("lights on now", timeout=3.0)
+
+    def test_spec_skill_deregister_removes_intent(self):
+        self._register_template("lights", ["turn on the lights", "lights on"])
+        self._emit(SKILL_DEREGISTER)
+        self._expect_no_match("lights on now", timeout=3.0)
+
+    # -- §8.5 disable / enable ------------------------------------------
+
+    def test_spec_disable_suppresses_intent(self):
+        """Disable drops the label (and its prototypes) from the match-eligible
+        set, suppressing the intent (§8.5)."""
+        self._register_template("lights", ["turn on the lights", "lights on"])
+        self._emit(INTENT_DISABLE, "lights")
+        self._expect_no_match("lights on now", timeout=3.0)
+
+    @pytest.mark.xfail(
+        strict=False,
+        reason="INTENT-4 §8.5: 'ovos.intent.enable re-arms a previously disabled "
+               "intent' — in m2v prototype mode disable drops the prototypes and "
+               "enable only restores label tracking (cannot re-embed samples), so "
+               "the intent does not match again; re-arming requires re-registration.",
+    )
+    def test_spec_enable_rearms_intent(self):
+        self._register_template("lights", ["turn on the lights", "lights on"])
+        self._emit(INTENT_DISABLE, "lights")
+        self._emit(INTENT_ENABLE, "lights")
+        msg = self._send_and_capture("lights on now",
+                                     expected_types=[f"{SKILL_ID}:lights"])
+        self.assertIsNotNone(msg, "intent should match again after enable")
+
+    # -- §11 negative: template engine ignores the keyword topic --------
+
+    def test_keyword_topic_does_not_match_on_template_engine(self):
+        self.mc.bus.emit(Message(REGISTER_KEYWORD, {
+            "skill_id": SKILL_ID, "intent_name": "lights",
+            "lang": "en-US",
+            "required": [{"name": "TurnOn", "samples": ["on"]},
+                         {"name": "Light", "samples": ["lights"]}],
+            "optional": [], "one_of": [], "excluded": [],
+        }, {"skill_id": SKILL_ID}))
+        self.assertNotIn(f"{SKILL_ID}:lights", self.pipeline.intents)
+        self._expect_no_match("lights on now", timeout=3.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_intent4.py
+++ b/tests/test_intent4.py
@@ -1,0 +1,272 @@
+"""Unit tests for OVOS-INTENT-4 template/entity registration adoption.
+
+m2v is a TEMPLATE-style engine (it matches on example utterances), so it
+consumes `ovos.intent.register.template` (§6) and `ovos.entity.register`
+(§7) in addition to the legacy `padatious:register_intent` topics. It does
+NOT consume `ovos.intent.register.keyword` (§11).
+"""
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+from ovos_bus_client.message import Message
+from ovos_spec_tools import SpecMessage
+
+
+def _make_prototype_pipeline(config=None):
+    """Prototype-mode pipeline with a mocked StaticModel + FakeBus."""
+    config = config or {}
+    config.setdefault("model", "fake-embed-model")
+    config["mode"] = "prototype"
+
+    mock_embed_model = MagicMock()
+    # identity rows so each sample becomes a distinct unit prototype
+    mock_embed_model.encode.side_effect = lambda sents: np.eye(len(sents), 4, dtype=np.float32)
+
+    fake_m2v = MagicMock()
+    fake_m2v.StaticModel.from_pretrained.return_value = mock_embed_model
+
+    with patch("ovos_m2v_pipeline.StaticModelPipeline"), \
+         patch("ovos_m2v_pipeline.Configuration", return_value={}), \
+         patch.dict(sys.modules, {"model2vec": fake_m2v}):
+        from ovos_m2v_pipeline import Model2VecIntentPipeline
+        from ovos_utils.fakebus import FakeBus
+        pipeline = Model2VecIntentPipeline(bus=FakeBus(), config=config)
+    pipeline.model = mock_embed_model
+    return pipeline
+
+
+def _make_classifier_pipeline(config=None):
+    """Classifier-mode pipeline with a mocked StaticModelPipeline + FakeBus."""
+    config = config or {}
+    config.setdefault("model", "fake-model")
+
+    mock_model = MagicMock()
+    mock_model.classes_ = np.array([])
+    mock_model.predict_proba.return_value = np.array([[]])
+
+    with patch("ovos_m2v_pipeline.StaticModelPipeline") as MockSMP, \
+         patch("ovos_m2v_pipeline.Configuration", return_value={}):
+        MockSMP.from_pretrained.return_value = mock_model
+        from ovos_m2v_pipeline import Model2VecIntentPipeline
+        from ovos_utils.fakebus import FakeBus
+        pipeline = Model2VecIntentPipeline(bus=FakeBus(), config=config)
+    pipeline.model = mock_model
+    return pipeline
+
+
+class TestIntent4Subscriptions(unittest.TestCase):
+    """The INTENT-4 topics are subscribed (and the keyword topic is NOT)."""
+
+    def _registered_topics(self, pipeline):
+        # FakeBus stores handlers in .ee (EventEmitter); fall back to events dict
+        try:
+            return set(pipeline.bus.ee._events.keys())
+        except AttributeError:
+            return set(getattr(pipeline.bus, "events", {}).keys())
+
+    def test_prototype_mode_subscribes_template_not_keyword(self):
+        p = _make_prototype_pipeline()
+        topics = self._registered_topics(p)
+        self.assertIn(SpecMessage.INTENT_REGISTER_TEMPLATE.value, topics)
+        self.assertIn(SpecMessage.ENTITY_REGISTER.value, topics)
+        self.assertIn(SpecMessage.INTENT_DEREGISTER.value, topics)
+        self.assertIn(SpecMessage.SKILL_DEREGISTER.value, topics)
+        self.assertNotIn(SpecMessage.INTENT_REGISTER_KEYWORD.value, topics)
+
+    def test_classifier_mode_subscribes_template_not_keyword(self):
+        p = _make_classifier_pipeline()
+        topics = self._registered_topics(p)
+        self.assertIn(SpecMessage.INTENT_REGISTER_TEMPLATE.value, topics)
+        self.assertNotIn(SpecMessage.INTENT_REGISTER_KEYWORD.value, topics)
+
+    def test_legacy_topics_still_subscribed(self):
+        p = _make_prototype_pipeline()
+        topics = self._registered_topics(p)
+        self.assertIn("padatious:register_intent", topics)
+        self.assertIn("detach_intent", topics)
+        self.assertIn("detach_skill", topics)
+
+
+class TestIntent4TemplateRegistration(unittest.TestCase):
+    def _register(self, p, skill_id="music.skill", intent_name="play_music",
+                  samples=None, lang="en-US"):
+        msg = Message(
+            SpecMessage.INTENT_REGISTER_TEMPLATE.value,
+            data={
+                "skill_id": skill_id,
+                "intent_name": intent_name,
+                "lang": lang,
+                "samples": samples if samples is not None else ["play music", "put on a song"],
+            },
+            context={"skill_id": skill_id},
+        )
+        p._handle_intent4_register_template(msg)
+
+    def test_register_accepted_and_label_tracked(self):
+        p = _make_prototype_pipeline()
+        self._register(p)
+        self.assertIn("music.skill:play_music", p.intents)
+        self.assertIn("music.skill:play_music", p.prototype_store.unique_labels)
+
+    def test_registered_intent_matches_utterance(self):
+        """Register via the template topic, then match an utterance.
+
+        The mock encoder maps the Nth registered sample to basis vector e_N.
+        With max_over_all the query that equals one prototype yields cosine 1.0.
+        """
+        p = _make_prototype_pipeline()
+        # encode returns deterministic basis vectors; register a single sample
+        self._register(p, samples=["play music"])
+        # query embedding identical to the stored prototype -> cosine 1.0
+        p.model.encode.side_effect = None
+        p.model.encode.return_value = np.array([[1.0, 0.0, 0.0, 0.0]], dtype=np.float32)
+        results = list(p._match("play music"))
+        self.assertEqual(len(results), 1)
+        skill_id, label, score = results[0]
+        self.assertEqual(label, "music.skill:play_music")
+        self.assertEqual(skill_id, "music.skill")
+        self.assertAlmostEqual(score, 1.0, places=4)
+
+    def test_bracket_templates_expanded(self):
+        p = _make_prototype_pipeline()
+        self._register(p, samples=["(play|put on) the music"])
+        # two expanded variants -> two prototypes for the label
+        n = (p.prototype_store.labels == "music.skill:play_music").sum()
+        self.assertEqual(n, 2)
+
+    def test_replacement_on_re_register(self):
+        p = _make_prototype_pipeline()
+        self._register(p, samples=["one"])
+        self._register(p, samples=["two"])  # same triple -> replaces (§8.1)
+        self.assertEqual((p.prototype_store.labels == "music.skill:play_music").sum(), 1)
+
+    def test_missing_samples_rejected(self):
+        p = _make_prototype_pipeline()
+        with patch("ovos_m2v_pipeline.LOG.warning") as warn:
+            self._register(p, samples=[])
+        self.assertNotIn("music.skill:play_music", p.intents)
+        warn.assert_called()
+
+    def test_missing_identity_rejected(self):
+        p = _make_prototype_pipeline()
+        msg = Message(SpecMessage.INTENT_REGISTER_TEMPLATE.value,
+                      data={"intent_name": "x", "samples": ["hi"]})
+        with patch("ovos_m2v_pipeline.LOG.warning") as warn:
+            p._handle_intent4_register_template(msg)
+        warn.assert_called()
+        self.assertEqual(len(p.prototype_store), 0)
+
+    def test_ignored_label_skipped(self):
+        p = _make_prototype_pipeline()
+        p.ignore_labels = ["music.skill:play_music"]
+        self._register(p)
+        self.assertEqual(len(p.prototype_store), 0)
+
+    def test_classifier_mode_tracks_label_only(self):
+        p = _make_classifier_pipeline()
+        msg = Message(SpecMessage.INTENT_REGISTER_TEMPLATE.value,
+                      data={"skill_id": "music.skill", "intent_name": "play_music",
+                            "lang": "en-US", "samples": ["play music"]})
+        p._handle_intent4_register_template(msg)
+        self.assertIn("music.skill:play_music", p.intents)
+        self.assertIsNone(p.prototype_store)
+
+
+class TestIntent4EntityRegistration(unittest.TestCase):
+    def test_entity_fills_template_slots(self):
+        p = _make_prototype_pipeline()
+        p._handle_intent4_register_entity(Message(
+            SpecMessage.ENTITY_REGISTER.value,
+            data={"skill_id": "music.skill", "entity_name": "engine",
+                  "lang": "en-US", "samples": ["spotify", "youtube"]},
+        ))
+        self.assertIn("engine", p.entities)
+        # register a template that references {engine}
+        p._handle_intent4_register_template(Message(
+            SpecMessage.INTENT_REGISTER_TEMPLATE.value,
+            data={"skill_id": "music.skill", "intent_name": "play_on",
+                  "lang": "en-US", "samples": ["play on {engine}"]},
+        ))
+        n = (p.prototype_store.labels == "music.skill:play_on").sum()
+        # two entity values -> two filled prototypes
+        self.assertEqual(n, 2)
+
+    def test_entity_missing_samples_rejected(self):
+        p = _make_prototype_pipeline()
+        with patch("ovos_m2v_pipeline.LOG.warning") as warn:
+            p._handle_intent4_register_entity(Message(
+                SpecMessage.ENTITY_REGISTER.value,
+                data={"skill_id": "s", "entity_name": "engine", "samples": []},
+            ))
+        self.assertNotIn("engine", p.entities)
+        warn.assert_called()
+
+    def test_unregistered_slot_left_literal(self):
+        p = _make_prototype_pipeline()
+        p._handle_intent4_register_template(Message(
+            SpecMessage.INTENT_REGISTER_TEMPLATE.value,
+            data={"skill_id": "music.skill", "intent_name": "play_on",
+                  "lang": "en-US", "samples": ["play on {engine}"]},
+        ))
+        # no entity registered -> single literal prototype, still accepted
+        self.assertIn("music.skill:play_on", p.intents)
+
+
+class TestIntent4Deregistration(unittest.TestCase):
+    def _register(self, p, skill_id="music.skill", intent_name="play_music"):
+        p._handle_intent4_register_template(Message(
+            SpecMessage.INTENT_REGISTER_TEMPLATE.value,
+            data={"skill_id": skill_id, "intent_name": intent_name,
+                  "lang": "en-US", "samples": ["play music"]},
+        ))
+
+    def test_deregister_intent(self):
+        p = _make_prototype_pipeline()
+        self._register(p)
+        p._handle_intent4_deregister_intent(Message(
+            SpecMessage.INTENT_DEREGISTER.value,
+            data={"skill_id": "music.skill", "intent_name": "play_music", "lang": "en-US"},
+        ))
+        self.assertNotIn("music.skill:play_music", p.intents)
+        self.assertNotIn("music.skill:play_music", p.prototype_store.unique_labels)
+
+    def test_deregister_skill_removes_all(self):
+        p = _make_prototype_pipeline()
+        self._register(p, intent_name="a")
+        self._register(p, intent_name="b")
+        self._register(p, skill_id="other.skill", intent_name="c")
+        p._handle_intent4_deregister_skill(Message(
+            SpecMessage.SKILL_DEREGISTER.value, data={"skill_id": "music.skill"},
+        ))
+        self.assertNotIn("music.skill:a", p.intents)
+        self.assertNotIn("music.skill:b", p.intents)
+        self.assertIn("other.skill:c", p.intents)
+
+    def test_deregister_entity(self):
+        p = _make_prototype_pipeline()
+        p.entities["engine"] = ["spotify"]
+        p._handle_intent4_deregister_entity(Message(
+            SpecMessage.ENTITY_DEREGISTER.value,
+            data={"skill_id": "music.skill", "entity_name": "engine", "lang": "en-US"},
+        ))
+        self.assertNotIn("engine", p.entities)
+
+    def test_disable_then_enable(self):
+        p = _make_prototype_pipeline()
+        self._register(p)
+        p._handle_intent4_disable(Message(
+            SpecMessage.INTENT_DISABLE.value,
+            data={"skill_id": "music.skill", "intent_name": "play_music", "lang": "en-US"},
+        ))
+        self.assertNotIn("music.skill:play_music", p.intents)
+        p._handle_intent4_enable(Message(
+            SpecMessage.INTENT_ENABLE.value,
+            data={"skill_id": "music.skill", "intent_name": "play_music", "lang": "en-US"},
+        ))
+        self.assertIn("music.skill:play_music", p.intents)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

m2v matches on example utterances → it is a **template-style** intent engine. This wires it up to the **OVOS-INTENT-4** registration bus topics **in addition to** the existing legacy topics (`padatious:register_intent`, `register_intent`, `detach_intent`, `detach_skill`), which are left fully intact.

Per the spec, m2v consumes the **template** registration topic (§6) and **NOT** the keyword topic (§11 — keyword engines only).

## Topics consumed (`ovos_spec_tools.SpecMessage`)

| Topic | § | Handling |
|-------|---|----------|
| `ovos.intent.register.template` | §6 | bracket-expand + entity-fill `samples` → embed as prototypes (prototype mode) / track the trained label (classifier mode) |
| `ovos.entity.register` | §7 | value-set hint; fills `{slot}` placeholders in template samples before embedding (prototype mode) |
| `ovos.intent.deregister` | §8.2 | drop the intent's prototypes + label |
| `ovos.entity.deregister` | §8.3 | drop the entity value-set |
| `ovos.skill.deregister` | §8.4 | drop everything for the skill_id |
| `ovos.intent.enable` / `ovos.intent.disable` | §8.5 | re-arm / suppress a label |

`ovos.intent.register.keyword` is **deliberately not subscribed**.

## Spec → m2v mapping

- §3.2 identity `(skill_id, intent_name)` → internal `"<skill_id>:<intent_name>"` label (the engine's existing label format).
- §6 `samples` → the per-intent example set fed to `PrototypeIntentStore.add` (same internal API the legacy `padatious:register_intent` handler uses). Templates are bracket-expanded; registered entity values fill `{slot}` placeholders (capped).
- §8.1 replacement is implicit — re-registering the same triple replaces (the store's `add` already removes-then-adds the label).
- Malformed payloads (missing identity/samples, zero non-empty expansions) are rejected with a WARN log per §5.3/§6.3/§7.2.
- Classifier mode (frozen model): registrations only gate which trained classes are match-eligible, exactly like the legacy manifest sync; entity slot-fill is a no-op.

## Tests

New `tests/test_intent4.py` (18 tests): subscription wiring (template subscribed, keyword not, legacy intact), template registration **and matching an utterance**, bracket expansion, entity slot-fill, implicit replacement, malformed rejection, and deregister/enable/disable. Existing suite (`tests/test_pipeline.py`, 80 tests) unchanged and green.

Adds `ovos-spec-tools>=0.10.0a1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for richer intent registration, including template-based utterances and entity value sets.
  * Enabled broader test coverage for intent handling through new automated checks.
  * Added a workflow to run end-to-end validation on pull requests and manually.

* **Bug Fixes**
  * Improved handling of intent enable/disable and remove actions so matching updates more reliably.
  * Prevented live-only tests from interrupting normal test collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->