### PR TITLE
feat: honor INTENT-4 §6.1 blacklist + session blacklists at match

### DIFF
--- a/ovos_m2v_pipeline/__init__.py
+++ b/ovos_m2v_pipeline/__init__.py
@@ -319,6 +319,11 @@ class Model2VecIntentPipeline(ConfidenceMatcherPipeline):
         #: holds bare-string keys or ``{"key", "scope"}`` mappings and is
         #: evaluated at match time via ``gate_satisfied``.
         self._context_gates: Dict[str, Tuple[list, list]] = {}
+        #: Per-label suppression phrases (OVOS-INTENT-4 §6.1 ``blacklist``),
+        #: keyed by intent label. A candidate is dropped at match time when the
+        #: utterance contains one of its label's blacklisted phrases. Named and
+        #: matched consistently with the padacioso engine's ``excluded_keywords``.
+        self.excluded_keywords: Dict[str, List[str]] = {}
 
         mode = self.config.get("mode", "classifier")
 
@@ -632,6 +637,10 @@ class Model2VecIntentPipeline(ConfidenceMatcherPipeline):
             self._intent4_warn(topic, message, "samples missing or empty")
             return
 
+        blacklist = message.data.get("blacklist")
+        if blacklist:  # §6.1 suppression phrases: drop matches containing these
+            self.excluded_keywords[label] = list(blacklist)
+
         # Classifier mode is frozen: only gate the (already trained) label.
         if self.prototype_store is None:
             self.intents.add(label)
@@ -701,6 +710,7 @@ class Model2VecIntentPipeline(ConfidenceMatcherPipeline):
             self.prototype_store.remove(label)
         self.intents.discard(label)
         self._context_gates.pop(label, None)
+        self.excluded_keywords.pop(label, None)
         LOG.debug(f"Model2Vec: deregistered INTENT-4 intent '{label}'")
 
     def _handle_intent4_deregister_entity(self, message: Message) -> None:
@@ -720,6 +730,8 @@ class Model2VecIntentPipeline(ConfidenceMatcherPipeline):
         self.intents = {i for i in self.intents if not i.startswith(skill_id + ":")}
         self._context_gates = {l: g for l, g in self._context_gates.items()
                                if not l.startswith(skill_id + ":")}
+        self.excluded_keywords = {i: kw for i, kw in self.excluded_keywords.items()
+                                  if not i.startswith(skill_id + ":")}
         LOG.debug(f"Model2Vec: deregistered all INTENT-4 registrations for skill '{skill_id}'")
 
     def _handle_intent4_disable(self, message: Message) -> None:
@@ -737,6 +749,7 @@ class Model2VecIntentPipeline(ConfidenceMatcherPipeline):
             self.prototype_store.remove(label)
         self.intents.discard(label)
         self._context_gates.pop(label, None)
+        self.excluded_keywords.pop(label, None)
         LOG.debug(f"Model2Vec: disabled INTENT-4 intent '{label}'")
 
     def _handle_intent4_enable(self, message: Message) -> None:
@@ -766,22 +779,65 @@ class Model2VecIntentPipeline(ConfidenceMatcherPipeline):
             return "stop.openvoiceos", "mycroft.stop"
         return label.split(":")[0], label
 
+    def _excluded_labels(self, utterance: str) -> List[str]:
+        """Labels whose §6.1 ``blacklist`` phrases occur in *utterance*.
+
+        Uses the same word-boundary convention as the padacioso engine's
+        ``_filter``: single-word phrases must match a whole token, multi-word
+        phrases match on a ``\\b``-delimited substring.
+        """
+        if not self.excluded_keywords:
+            return []
+        excluded: List[str] = []
+        q_lower = utterance.lower()
+        query_words = set(q_lower.split())
+        for label, phrases in self.excluded_keywords.items():
+            def _kw_hit(kw: str, _qw=query_words, _ql=q_lower) -> bool:
+                kw = kw.lower()
+                if " " not in kw:
+                    return kw in _qw
+                return bool(re.search(r"\b" + re.escape(kw) + r"\b", _ql))
+            if any(_kw_hit(p) for p in phrases):
+                excluded.append(label)
+        return excluded
+
+    def _session_blacklists(self, message: Optional[Message]) -> Tuple[frozenset, frozenset]:
+        """``(blacklisted_intents, blacklisted_skills)`` for the caller's session.
+
+        Mirrors adapt/padatious: candidates whose intent label or skill_id is
+        blacklisted in the session are dropped at match time.
+        """
+        if message is None:
+            return frozenset(), frozenset()
+        try:
+            sess = SessionManager.get(message)
+        except Exception:
+            return frozenset(), frozenset()
+        return (frozenset(sess.blacklisted_intents or []),
+                frozenset(sess.blacklisted_skills or []))
+
     def _match(self, utterance: str,
                message: Optional[Message] = None) -> Iterable[Tuple[str, str, float]]:
         """Yield ``(skill_id, label, score)`` tuples sorted by score descending.
 
+        Candidates suppressed by a §6.1 template ``blacklist`` phrase, or by the
+        session's ``blacklisted_intents`` / ``blacklisted_skills``, are dropped.
+
         Args:
             utterance: The utterance to match.
             message: The incoming bus message (used to read session.pipeline for
-                     special-label gating in both classifier and prototype modes).
+                     special-label gating, plus the session blacklists).
         """
         if self.prototype_store is not None:
             candidates = self._match_prototype(utterance, message)
         else:
             candidates = self._match_classifier(utterance, message)
-        # OVOS-CONTEXT-1 §6/§6.1: drop candidates whose requires/excludes
-        # context gate is not satisfied by the caller session's intent_context.
+        # OVOS-CONTEXT-1 §6/§6.1 context gate + OVOS-INTENT-4 §6.1 blacklist +
+        # session blacklists — applied together so a candidate must survive all
+        # three to be yielded.
         intent_context = (SessionManager.get(message).intent_context or {}) if self._context_gates else {}
+        excluded = self._excluded_labels(utterance)
+        blacklisted_intents, blacklisted_skills = self._session_blacklists(message)
         for skill_id, label, score in candidates:
             gate = self._context_gates.get(label)
             if gate is not None:
@@ -789,6 +845,12 @@ class Model2VecIntentPipeline(ConfidenceMatcherPipeline):
                 if not gate_satisfied(intent_context, requires, excludes, owner_id=skill_id):
                     LOG.debug(f"discarding '{label}': CONTEXT-1 gate not satisfied")
                     continue
+            if label in excluded:
+                LOG.debug(f"discarding match: {label} - utterance hits §6.1 blacklist")
+                continue
+            if label in blacklisted_intents or skill_id in blacklisted_skills:
+                LOG.debug(f"discarding match: {label} - blacklisted in session")
+                continue
             yield skill_id, label, score
 
     def _match_classifier(self, utterance: str,

--- a/tests/test_intent4.py
+++ b/tests/test_intent4.py
@@ -347,6 +347,88 @@ class TestIntent4ContextGating(unittest.TestCase):
         p._handle_intent4_deregister_skill(Message(
             SpecMessage.SKILL_DEREGISTER.value, data={"skill_id": "music.skill"}))
         self.assertNotIn("music.skill:play_music", p._context_gates)
+class TestIntent4Blacklist(unittest.TestCase):
+    """OVOS-INTENT-4 §6.1 template blacklist + session-level blacklists.
+
+    m2v was the only matcher engine that ignored these; the filter mirrors
+    padacioso's word-boundary ``_filter`` and adapt/padatious' session
+    ``blacklisted_intents`` / ``blacklisted_skills`` gating.
+    """
+
+    def _register(self, p, skill_id="music.skill", intent_name="play_music",
+                  samples=None, blacklist=None, lang="en-US"):
+        data = {
+            "skill_id": skill_id,
+            "intent_name": intent_name,
+            "lang": lang,
+            "samples": samples if samples is not None else ["play music"],
+        }
+        if blacklist is not None:
+            data["blacklist"] = blacklist
+        p._handle_intent4_register_template(
+            Message(SpecMessage.INTENT_REGISTER_TEMPLATE.value,
+                    data=data, context={"skill_id": skill_id}))
+
+    @staticmethod
+    def _pin_query_vector(p):
+        # query embedding identical to the stored prototype -> cosine 1.0
+        p.model.encode.side_effect = None
+        p.model.encode.return_value = np.array([[1.0, 0.0, 0.0, 0.0]],
+                                               dtype=np.float32)
+
+    def _session_message(self, **session_kwargs):
+        from ovos_bus_client.session import Session
+        sess = Session(session_id="s")
+        for k, v in session_kwargs.items():
+            setattr(sess, k, v)
+        return Message("recognizer_loop:utterance",
+                       context={"session": sess.serialize()})
+
+    def test_blacklist_stored_on_register(self):
+        p = _make_prototype_pipeline()
+        self._register(p, samples=["play music"], blacklist=["trailer"])
+        self.assertEqual(p.excluded_keywords["music.skill:play_music"],
+                         ["trailer"])
+
+    def test_blacklist_suppresses_match(self):
+        p = _make_prototype_pipeline()
+        self._register(p, samples=["play music"], blacklist=["trailer"])
+        self._pin_query_vector(p)
+        # (a) blacklisted phrase present -> no match (§6.1)
+        self.assertEqual(list(p._match("play the trailer")), [])
+        # (a) clean utterance still matches
+        results = list(p._match("play music"))
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0][1], "music.skill:play_music")
+
+    def test_session_blacklisted_intent_dropped(self):
+        p = _make_prototype_pipeline()
+        self._register(p, samples=["play music"])
+        self._pin_query_vector(p)
+        # control: no blacklist -> matches
+        self.assertEqual(len(list(p._match("play music"))), 1)
+        # (b) intent blacklisted in session -> dropped
+        msg = self._session_message(
+            blacklisted_intents=["music.skill:play_music"])
+        self.assertEqual(list(p._match("play music", msg)), [])
+
+    def test_session_blacklisted_skill_dropped(self):
+        p = _make_prototype_pipeline()
+        self._register(p, samples=["play music"])
+        self._pin_query_vector(p)
+        # (b) skill blacklisted in session -> dropped
+        msg = self._session_message(blacklisted_skills=["music.skill"])
+        self.assertEqual(list(p._match("play music", msg)), [])
+
+    def test_deregister_intent_drops_blacklist(self):
+        p = _make_prototype_pipeline()
+        self._register(p, samples=["play music"], blacklist=["trailer"])
+        p._handle_intent4_deregister_intent(Message(
+            SpecMessage.INTENT_DEREGISTER.value,
+            data={"skill_id": "music.skill", "intent_name": "play_music",
+                  "lang": "en-US"}))
+        self.assertNotIn("music.skill:play_music", p.excluded_keywords)
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

m2v was the **one** matcher engine that ignored OVOS-INTENT-4 §6.1 blacklist enforcement. Every other engine (adapt/padatious/padacioso/nebulento/palavreado) supports both the template `blacklist` field and session-level `blacklisted_intents`/`blacklisted_skills`. This closes that gap.

## Changes (`ovos_m2v_pipeline/__init__.py`)

- **Register**: `_handle_intent4_register_template` now stores `message.data["blacklist"]` (§6.1 suppression phrases) in a new `self.excluded_keywords` dict keyed by intent label. Cleaned up on deregister-intent, disable, and skill-deregister.
- **Match**: the shared `_match` path filters candidates from both classifier and prototype modes:
  - drops any label whose utterance contains a blacklisted phrase (`_excluded_labels`, word-boundary matching mirroring padacioso's `_filter` — single-word phrases match a whole token, multi-word use `\b`-delimited regex);
  - drops any candidate whose label is in `session.blacklisted_intents` or whose `skill_id` is in `session.blacklisted_skills` (`_session_blacklists` via `SessionManager.get`, mirroring adapt `opm.py:184-185` / padatious `opm.py:707-713`).

Naming (`excluded_keywords`) follows the padacioso engine for cross-engine consistency.

## Tests (`tests/test_intent4.py`, new `TestIntent4Blacklist`)

- (a) template blacklist suppresses a match when the phrase is present, still matches otherwise;
- (b) a session-blacklisted intent is dropped; a session-blacklisted skill is dropped;
- blacklist stored on register; dropped on deregister.

Full unit suite green (132 passed) in a fresh uv venv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)