### PR TITLE
feat: enforce OVOS-CONTEXT-1 requires/excludes_context gating at match

### DIFF
--- a/ovos_m2v_pipeline/__init__.py
+++ b/ovos_m2v_pipeline/__init__.py
@@ -11,6 +11,7 @@ from ovos_bus_client.session import SessionManager
 from ovos_config.config import Configuration
 from ovos_plugin_manager.templates.pipeline import IntentHandlerMatch, ConfidenceMatcherPipeline
 from ovos_spec_tools import SpecMessage
+from ovos_spec_tools.context import gate_satisfied
 from ovos_utils.bracket_expansion import expand_template
 from ovos_utils.fakebus import FakeBus
 from ovos_utils.log import LOG
@@ -313,6 +314,11 @@ class Model2VecIntentPipeline(ConfidenceMatcherPipeline):
         #: name (lowercase). Used to fill ``{slot}`` placeholders in template
         #: samples before embedding. Disabled (left empty) in classifier mode.
         self.entities: Dict[str, List[str]] = {}
+        #: OVOS-CONTEXT-1 §6/§6.1 gating declarations per registered label,
+        #: keyed by label -> (requires_context, excludes_context). Each list
+        #: holds bare-string keys or ``{"key", "scope"}`` mappings and is
+        #: evaluated at match time via ``gate_satisfied``.
+        self._context_gates: Dict[str, Tuple[list, list]] = {}
 
         mode = self.config.get("mode", "classifier")
 
@@ -629,6 +635,7 @@ class Model2VecIntentPipeline(ConfidenceMatcherPipeline):
         # Classifier mode is frozen: only gate the (already trained) label.
         if self.prototype_store is None:
             self.intents.add(label)
+            self._store_context_gate(label, message)
             LOG.debug(f"Model2Vec: tracking INTENT-4 template label '{label}'")
             return
 
@@ -644,7 +651,19 @@ class Model2VecIntentPipeline(ConfidenceMatcherPipeline):
             return
         n = self.prototype_store.add(self.model, label, expanded, k=self._prototype_k)
         self.intents.add(label)
+        self._store_context_gate(label, message)
         LOG.debug(f"Prototype store: added {n} prototype(s) for INTENT-4 template '{label}'")
+
+    def _store_context_gate(self, label: str, message: Message) -> None:
+        """Record OVOS-CONTEXT-1 §6/§6.1 ``requires_context`` /
+        ``excludes_context`` declarations for ``label`` (if any) so they can be
+        enforced at match time. Absent declarations clear any stale entry."""
+        requires = message.data.get("requires_context")
+        excludes = message.data.get("excludes_context")
+        if requires or excludes:
+            self._context_gates[label] = (requires or [], excludes or [])
+        else:
+            self._context_gates.pop(label, None)
 
     def _handle_intent4_register_entity(self, message: Message) -> None:
         """Register an entity value-set hint (§7). No-op in classifier mode."""
@@ -681,6 +700,7 @@ class Model2VecIntentPipeline(ConfidenceMatcherPipeline):
         if self.prototype_store is not None:
             self.prototype_store.remove(label)
         self.intents.discard(label)
+        self._context_gates.pop(label, None)
         LOG.debug(f"Model2Vec: deregistered INTENT-4 intent '{label}'")
 
     def _handle_intent4_deregister_entity(self, message: Message) -> None:
@@ -698,6 +718,8 @@ class Model2VecIntentPipeline(ConfidenceMatcherPipeline):
         if self.prototype_store is not None:
             self.prototype_store.remove_skill(skill_id)
         self.intents = {i for i in self.intents if not i.startswith(skill_id + ":")}
+        self._context_gates = {l: g for l, g in self._context_gates.items()
+                               if not l.startswith(skill_id + ":")}
         LOG.debug(f"Model2Vec: deregistered all INTENT-4 registrations for skill '{skill_id}'")
 
     def _handle_intent4_disable(self, message: Message) -> None:
@@ -714,6 +736,7 @@ class Model2VecIntentPipeline(ConfidenceMatcherPipeline):
         if self.prototype_store is not None:
             self.prototype_store.remove(label)
         self.intents.discard(label)
+        self._context_gates.pop(label, None)
         LOG.debug(f"Model2Vec: disabled INTENT-4 intent '{label}'")
 
     def _handle_intent4_enable(self, message: Message) -> None:
@@ -753,9 +776,20 @@ class Model2VecIntentPipeline(ConfidenceMatcherPipeline):
                      special-label gating in both classifier and prototype modes).
         """
         if self.prototype_store is not None:
-            yield from self._match_prototype(utterance, message)
+            candidates = self._match_prototype(utterance, message)
         else:
-            yield from self._match_classifier(utterance, message)
+            candidates = self._match_classifier(utterance, message)
+        # OVOS-CONTEXT-1 §6/§6.1: drop candidates whose requires/excludes
+        # context gate is not satisfied by the caller session's intent_context.
+        intent_context = (SessionManager.get(message).intent_context or {}) if self._context_gates else {}
+        for skill_id, label, score in candidates:
+            gate = self._context_gates.get(label)
+            if gate is not None:
+                requires, excludes = gate
+                if not gate_satisfied(intent_context, requires, excludes, owner_id=skill_id):
+                    LOG.debug(f"discarding '{label}': CONTEXT-1 gate not satisfied")
+                    continue
+            yield skill_id, label, score
 
     def _match_classifier(self, utterance: str,
                            message: Optional[Message] = None) -> Iterable[Tuple[str, str, float]]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "ovos-bus-client>=2.5.1a1,<3.0.0",
     "ovos-config",
     "ovos-utils>=0.3.4,<1.0.0",
-    "ovos-spec-tools>=0.16.1a2",
+    "ovos-spec-tools>=1.4.0a1",
     "model2vec[inference]",
 ]
 
@@ -37,7 +37,7 @@ test = [
     # INTENT-4 consumer e2e stack floor (ovos.intent.register.* topics +
     # E2EPipelineHarness namespace flags). Mirrors ovos-test-harness@dev.
     "ovos-bus-client>=2.5.1a1,<3.0.0",
-    "ovos-spec-tools>=0.16.1a2",
+    "ovos-spec-tools>=1.4.0a1",
 ]
 
 [project.urls]

--- a/tests/test_intent4.py
+++ b/tests/test_intent4.py
@@ -268,5 +268,86 @@ class TestIntent4Deregistration(unittest.TestCase):
         self.assertIn("music.skill:play_music", p.intents)
 
 
+class TestIntent4ContextGating(unittest.TestCase):
+    """OVOS-CONTEXT-1 §6/§6.1 requires_context / excludes_context gating."""
+
+    def _register(self, p, requires=None, excludes=None,
+                  skill_id="music.skill", intent_name="play_music"):
+        data = {"skill_id": skill_id, "intent_name": intent_name,
+                "lang": "en-US", "samples": ["play music"]}
+        if requires is not None:
+            data["requires_context"] = requires
+        if excludes is not None:
+            data["excludes_context"] = excludes
+        p._handle_intent4_register_template(Message(
+            SpecMessage.INTENT_REGISTER_TEMPLATE.value, data=data,
+            context={"skill_id": skill_id}))
+
+    def _match_with_context(self, p, intent_context):
+        # query embedding identical to the single stored prototype -> cosine 1.0
+        p.model.encode.side_effect = None
+        p.model.encode.return_value = np.array([[1.0, 0.0, 0.0, 0.0]], dtype=np.float32)
+        sess = MagicMock()
+        sess.intent_context = intent_context
+        with patch("ovos_m2v_pipeline.SessionManager.get", return_value=sess):
+            return list(p._match("play music"))
+
+    def test_gate_stored_on_register(self):
+        p = _make_prototype_pipeline()
+        self._register(p, requires=["mode"], excludes=[{"key": "busy", "scope": "shared"}])
+        self.assertIn("music.skill:play_music", p._context_gates)
+        requires, excludes = p._context_gates["music.skill:play_music"]
+        self.assertEqual(requires, ["mode"])
+        self.assertEqual(excludes, [{"key": "busy", "scope": "shared"}])
+
+    def test_requires_context_present_matches(self):
+        p = _make_prototype_pipeline()
+        self._register(p, requires=["mode"])
+        # private key resolves to "<skill_id>:mode"
+        results = self._match_with_context(p, {"music.skill:mode": {"value": "party"}})
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0][1], "music.skill:play_music")
+
+    def test_requires_context_absent_dropped(self):
+        p = _make_prototype_pipeline()
+        self._register(p, requires=["mode"])
+        results = self._match_with_context(p, {})
+        self.assertEqual(results, [])
+
+    def test_excludes_context_present_dropped(self):
+        p = _make_prototype_pipeline()
+        self._register(p, excludes=["busy"])
+        results = self._match_with_context(p, {"music.skill:busy": {"value": True}})
+        self.assertEqual(results, [])
+
+    def test_excludes_context_absent_matches(self):
+        p = _make_prototype_pipeline()
+        self._register(p, excludes=["busy"])
+        results = self._match_with_context(p, {})
+        self.assertEqual(len(results), 1)
+
+    def test_ungated_intent_always_matches(self):
+        p = _make_prototype_pipeline()
+        self._register(p)  # no requires/excludes
+        self.assertNotIn("music.skill:play_music", p._context_gates)
+        results = self._match_with_context(p, {})
+        self.assertEqual(len(results), 1)
+
+    def test_gate_cleared_on_deregister(self):
+        p = _make_prototype_pipeline()
+        self._register(p, requires=["mode"])
+        p._handle_intent4_deregister_intent(Message(
+            SpecMessage.INTENT_DEREGISTER.value,
+            data={"skill_id": "music.skill", "intent_name": "play_music", "lang": "en-US"}))
+        self.assertNotIn("music.skill:play_music", p._context_gates)
+
+    def test_gate_cleared_on_skill_deregister(self):
+        p = _make_prototype_pipeline()
+        self._register(p, requires=["mode"])
+        p._handle_intent4_deregister_skill(Message(
+            SpecMessage.SKILL_DEREGISTER.value, data={"skill_id": "music.skill"}))
+        self.assertNotIn("music.skill:play_music", p._context_gates)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What

Enforces OVOS-CONTEXT-1 \`requires_context\` / \`excludes_context\` gating at match time in the model2vec pipeline, using \`from ovos_spec_tools.context import gate_satisfied\`.

## How

- **Storage** — \`ovos.intent.register.template\` payloads MAY carry optional \`requires_context\` / \`excludes_context\` (each a list of bare-string keys or \`{"key","scope":"private"|"shared"}\` mappings, default private). These are recorded per registered label in \`self._context_gates\` (both prototype and classifier mode) via \`_store_context_gate\`, and cleaned up on intent-deregister, disable, and skill-deregister. A registration carrying neither declaration leaves/clears any entry, so ungated intents are untouched.
- **Enforcement** — in \`_match\`, after candidate labels are produced, any candidate whose \`gate_satisfied(SessionManager.get(message).intent_context or {}, requires, excludes, owner_id=skill_id)\` is False is dropped. Liveness / scope / decay are handled entirely inside \`gate_satisfied\` — not reimplemented here.

Additive and back-compatible.

## spec-tools floor

Bumps \`ovos-spec-tools\` floor to \`>=1.4.0a1\` — the \`ovos_spec_tools.context\` module lives on the **unpublished** branch \`feat/context-1-gating-helpers\` (currently versioned 1.2.2a1). This PR should not merge until that helper is released as >=1.4.0a1.

Local test install:
\`\`\`
uv pip install --prerelease=allow "git+https://github.com/OpenVoiceOS/ovos-spec-tools@feat/context-1-gating-helpers"
\`\`\`

## Tests

New \`TestIntent4ContextGating\` in \`tests/test_intent4.py\`: gate stored on register; requires_context present-vs-absent; excludes_context present-vs-absent; ungated always matches; gate cleared on deregister / skill-deregister. Full suite (26 tests) passes in a fresh uv venv against the spec-tools branch.

## Composition note

This branches off \`origin/dev\`, independent of the open blacklist PR (#45, \`feat/intent4-blacklist\`); the two compose at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)