### PR TITLE
fix: skip malformed templates during intent registration

### DIFF
--- a/ovos_m2v_pipeline/__init__.py
+++ b/ovos_m2v_pipeline/__init__.py
@@ -12,7 +12,7 @@ from ovos_config.config import Configuration
 from ovos_plugin_manager.templates.pipeline import IntentHandlerMatch, ConfidenceMatcherPipeline
 from ovos_spec_tools import SpecMessage
 from ovos_spec_tools.context import gate_satisfied
-from ovos_utils.bracket_expansion import expand_template
+from ovos_spec_tools.expansion import expand as expand_template
 from ovos_utils.fakebus import FakeBus
 from ovos_utils.log import LOG
 
@@ -248,8 +248,11 @@ def _parse_intent_file(path: str) -> List[str]:
     """Return expanded, non-empty, non-comment lines from a Padatious ``.intent`` file.
 
     Template syntax (``(a|b)``, ``[optional]``) is expanded via
-    ``ovos_utils.bracket_expansion.expand_template`` so that every concrete
+    ``ovos_spec_tools.expansion.expand`` so that every concrete
     utterance variant is represented as a separate prototype.
+
+    Malformed lines are logged and skipped so that a single bad template
+    never discards the rest of the file.
     """
     try:
         sentences: List[str] = []
@@ -257,7 +260,11 @@ def _parse_intent_file(path: str) -> List[str]:
             for line in fh:
                 line = line.strip()
                 if line and not line.lstrip().startswith("#"):
-                    sentences.extend(expand_template(line))
+                    try:
+                        sentences.extend(expand_template(line))
+                    except Exception as exc:
+                        LOG.warning(f"Skipping malformed template {line!r} "
+                                    f"in '{path}': {exc}")
         return sentences
     except OSError as exc:
         LOG.warning(f"Could not read intent file '{path}': {exc}")
@@ -518,7 +525,11 @@ class Model2VecIntentPipeline(ConfidenceMatcherPipeline):
         if inline:
             sentences: List[str] = []
             for s in inline:
-                sentences.extend(expand_template(s))
+                try:
+                    sentences.extend(expand_template(s))
+                except Exception as exc:
+                    LOG.warning(f"Skipping malformed template {s!r} for "
+                                f"Padatious intent '{name}': {exc}")
         else:
             file_name: str = message.data.get("file_name", "")
             sentences = _parse_intent_file(file_name) if file_name else []
@@ -526,9 +537,14 @@ class Model2VecIntentPipeline(ConfidenceMatcherPipeline):
         if not sentences:
             LOG.warning(f"No examples found for Padatious intent '{name}' - skipping prototypes")
             return
-        n = self.prototype_store.add(
-            self.model, name, sentences, k=self._prototype_k
-        )
+        try:
+            n = self.prototype_store.add(
+                self.model, name, sentences, k=self._prototype_k
+            )
+        except Exception as exc:
+            LOG.error(f"Failed to add prototypes for Padatious intent "
+                      f"'{name}': {exc}")
+            return
         self.intents.add(name)
         LOG.debug(f"Prototype store: added {n} prototype(s) for '{name}'")
 

--- a/tests/test_template_expansion.py
+++ b/tests/test_template_expansion.py
@@ -1,0 +1,101 @@
+"""Malformed Padatious templates must never abort intent registration.
+
+Real-world skill locale files contain malformed template lines
+(translated slot names such as ``{Medien}``, truncated braces such as
+``{location``, adjacent slots such as ``{a}{b}``, and bracketed markers
+such as ``[UNUSED]``).  One bad line must be logged and skipped while
+every valid line keeps registering.
+"""
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+from ovos_bus_client.message import Message
+
+from ovos_m2v_pipeline import _parse_intent_file
+
+
+def _make_prototype_pipeline():
+    config = {"model": "fake-embed-model", "mode": "prototype"}
+
+    mock_embed_model = MagicMock()
+    mock_embed_model.encode.return_value = np.zeros((1, 4), dtype=np.float32)
+
+    fake_m2v = MagicMock()
+    fake_m2v.StaticModel.from_pretrained.return_value = mock_embed_model
+
+    with patch("ovos_m2v_pipeline.StaticModelPipeline"), \
+         patch("ovos_m2v_pipeline.Configuration", return_value={}), \
+         patch.dict(sys.modules, {"model2vec": fake_m2v}):
+        from ovos_m2v_pipeline import Model2VecIntentPipeline
+        from ovos_utils.fakebus import FakeBus
+        pipeline = Model2VecIntentPipeline(bus=FakeBus(), config=config)
+
+    pipeline.model = mock_embed_model
+    pipeline.prototype_store = MagicMock()
+    pipeline.prototype_store.add.return_value = 1
+    return pipeline
+
+
+class TestParseIntentFile(unittest.TestCase):
+    def _write(self, tmp, lines):
+        import os
+        path = os.path.join(tmp, "demo.intent")
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write("\n".join(lines))
+        return path
+
+    def test_malformed_lines_skipped_valid_kept(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write(tmp, [
+                "play {Medien}",          # invalid (uppercase) slot name
+                "weather in {location",   # truncated brace
+                "{first}{second}",        # adjacent slots
+                "[UNUSED] noise",         # bracketed marker (valid optional)
+                "play {media}",
+                "(start|begin) {media}",
+            ])
+            sentences = _parse_intent_file(path)
+        self.assertIn("play {media}", sentences)
+        self.assertIn("start {media}", sentences)
+        self.assertIn("begin {media}", sentences)
+        self.assertIn("noise", sentences)
+        self.assertNotIn("play {Medien}", sentences)
+        self.assertNotIn("weather in {location", sentences)
+        self.assertNotIn("{first}{second}", sentences)
+
+    def test_all_malformed_yields_empty(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write(tmp, ["{Medien}", "{oops", "{a}{b}"])
+            self.assertEqual(_parse_intent_file(path), [])
+
+
+class TestRegisterPadatiousInlineSamples(unittest.TestCase):
+    def test_mixed_samples_register_valid_ones(self):
+        pipeline = _make_prototype_pipeline()
+        msg = Message("padatious:register_intent", data={
+            "name": "test_skill:demo.intent",
+            "samples": ["play {Medien}", "tune to {station",
+                        "{a}{b}", "play {media}"],
+        })
+        pipeline._handle_register_padatious(msg)
+        self.assertIn("test_skill:demo.intent", pipeline.intents)
+        args = pipeline.prototype_store.add.call_args
+        self.assertEqual(args[0][2], ["play {media}"])
+
+    def test_malformed_only_does_not_raise_or_register(self):
+        pipeline = _make_prototype_pipeline()
+        msg = Message("padatious:register_intent", data={
+            "name": "test_skill:demo.intent",
+            "samples": ["{Medien}", "{loc", "{a}{b}"],
+        })
+        pipeline._handle_register_padatious(msg)
+        self.assertNotIn("test_skill:demo.intent", pipeline.intents)
+        pipeline.prototype_store.add.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
One malformed sample in a Padatious intent file or inline sample list (e.g. a translated slot name like `{Medien}`, a truncated `{location`, or adjacent slots `{a}{b}`) raised `MalformedTemplate` through the message-bus emitter in `_handle_register_padatious`, aborting registration of every sample for that intent.

## Changes
- `_parse_intent_file` and the inline-samples path in `_handle_register_padatious` expand each template individually; malformed ones are logged with the offending template and skipped, keeping all valid samples.
- The `prototype_store.add` call is guarded so no registration error escapes the bus handler.
- Replace the deprecated `ovos_utils.bracket_expansion.expand_template` import (deprecation warning fired on every call) with `ovos_spec_tools.expansion.expand`, already a declared dependency.
- Regression tests covering invalid slot names, unbalanced braces, adjacent slots, bracketed markers, and mixed valid/malformed sample lists, for both the file and inline paths.

## Testing
Full test suite in a fresh uv venv: 144 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)