### PR TITLE
fix: log skipped templates with full registration identifiers

### DIFF
--- a/ovos_m2v_pipeline/__init__.py
+++ b/ovos_m2v_pipeline/__init__.py
@@ -244,15 +244,17 @@ class PrototypeIntentStore:
         )
 
 
-def _parse_intent_file(path: str) -> List[str]:
+def _parse_intent_file(path: str, ctx: str = "") -> List[str]:
     """Return expanded, non-empty, non-comment lines from a Padatious ``.intent`` file.
 
     Template syntax (``(a|b)``, ``[optional]``) is expanded via
     ``ovos_spec_tools.expansion.expand`` so that every concrete
     utterance variant is represented as a separate prototype.
 
-    Malformed lines are logged and skipped so that a single bad template
-    never discards the rest of the file.
+    A line that is not parsable as OVOS-INTENT-1 grammar is logged and
+    skipped so that a single bad template never discards the rest of the
+    file (OVOS-INTENT-4 §6.3); *ctx* carries the §5.3 identifier fields
+    for those warnings.
     """
     try:
         sentences: List[str] = []
@@ -263,8 +265,8 @@ def _parse_intent_file(path: str) -> List[str]:
                     try:
                         sentences.extend(expand_template(line))
                     except Exception as exc:
-                        LOG.warning(f"Skipping malformed template {line!r} "
-                                    f"in '{path}': {exc}")
+                        LOG.warning(f"skipping malformed template {line!r}: "
+                                    f"{exc} {ctx}")
         return sentences
     except OSError as exc:
         LOG.warning(f"Could not read intent file '{path}': {exc}")
@@ -521,6 +523,10 @@ class Model2VecIntentPipeline(ConfidenceMatcherPipeline):
         if not name or name in self.ignore_labels:
             return
 
+        skill_id = message.data.get("skill_id") or message.context.get("skill_id")
+        ctx = (f"[skill_id={skill_id!r} name={name!r} "
+               f"lang={message.data.get('lang')!r} topic={message.msg_type}]")
+
         inline = message.data.get("samples") or []
         if inline:
             sentences: List[str] = []
@@ -528,14 +534,14 @@ class Model2VecIntentPipeline(ConfidenceMatcherPipeline):
                 try:
                     sentences.extend(expand_template(s))
                 except Exception as exc:
-                    LOG.warning(f"Skipping malformed template {s!r} for "
-                                f"Padatious intent '{name}': {exc}")
+                    LOG.warning(f"skipping malformed template {s!r}: {exc} {ctx}")
         else:
             file_name: str = message.data.get("file_name", "")
-            sentences = _parse_intent_file(file_name) if file_name else []
+            sentences = _parse_intent_file(file_name, ctx) if file_name else []
 
         if not sentences:
-            LOG.warning(f"No examples found for Padatious intent '{name}' - skipping prototypes")
+            # zero valid templates -> the whole registration is malformed
+            LOG.warning(f"rejecting registration: no valid template remains {ctx}")
             return
         try:
             n = self.prototype_store.add(
@@ -668,8 +674,13 @@ class Model2VecIntentPipeline(ConfidenceMatcherPipeline):
         for s in self._expand_entities(list(samples)):
             try:
                 expanded.extend(expand_template(s))
-            except Exception:
-                expanded.append(s)
+            except Exception as exc:
+                # skip the unparsable template, keep the valid ones (§6.3)
+                LOG.warning(
+                    f"skipping malformed template {s!r}: {exc} "
+                    f"[skill_id={message.data.get('skill_id')!r} "
+                    f"name={message.data.get('intent_name')!r} "
+                    f"lang={message.data.get('lang')!r} topic={topic}]")
         expanded = [s for s in (e.strip() for e in expanded) if s]
         if not expanded:  # zero non-empty expansions -> malformed (§6.3)
             self._intent4_warn(topic, message, "samples expand to zero non-empty templates")
@@ -710,10 +721,16 @@ class Model2VecIntentPipeline(ConfidenceMatcherPipeline):
                     v = v.strip()
                     if v:
                         values.add(v)
-            except Exception:
-                v = str(s).strip()
-                if v:
-                    values.add(v)
+            except Exception as exc:
+                # skip the unparsable entry, keep the valid ones (§7.2)
+                LOG.warning(
+                    f"skipping malformed entity sample {s!r}: {exc} "
+                    f"[skill_id={message.data.get('skill_id')!r} "
+                    f"name={name!r} "
+                    f"lang={message.data.get('lang')!r} topic={topic}]")
+        if not values:  # zero valid entries -> malformed (§7.2)
+            self._intent4_warn(topic, message, "no valid entity sample remains")
+            return
         self.entities[name.lower()] = list(values)
         LOG.debug(f"Model2Vec: registered INTENT-4 entity '{name}' ({len(values)} values)")
 

--- a/tests/test_template_expansion.py
+++ b/tests/test_template_expansion.py
@@ -1,12 +1,17 @@
-"""Malformed Padatious templates must never abort intent registration.
+"""Malformed-template tolerance during intent registration (OVOS-INTENT-4).
 
 Real-world skill locale files contain malformed template lines
 (translated slot names such as ``{Medien}``, truncated braces such as
-``{location``, adjacent slots such as ``{a}{b}``, and bracketed markers
-such as ``[UNUSED]``).  One bad line must be logged and skipped while
-every valid line keeps registering.
+``{location``, adjacent slots such as ``{a}{b}``). A consuming plugin
+skips each such template with a WARN carrying the §5.3 fields
+(skill_id, intent_name, lang, topic, reason) and indexes the remaining
+valid templates; the registration is rejected only when no valid
+template remains. Registrations are per-lang messages, so a rejected
+registration in one lang never affects another lang's registrations.
 """
+import os
 import sys
+import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -14,6 +19,10 @@ import numpy as np
 from ovos_bus_client.message import Message
 
 from ovos_m2v_pipeline import _parse_intent_file
+
+MALFORMED = ["play {Medien}", "weather in {location", "{first}{second}"]
+VALID = ["play {media}", "(start|begin) {media}", "[UNUSED] noise"]
+FIELDS = ["'test_skill'", "en-US"]
 
 
 def _make_prototype_pipeline():
@@ -38,26 +47,25 @@ def _make_prototype_pipeline():
     return pipeline
 
 
+def _padatious_msg(samples, name="test_skill:demo.intent",
+                   skill_id="test_skill", lang="en-US"):
+    return Message("padatious:register_intent",
+                   data={"name": name, "samples": samples,
+                         "skill_id": skill_id, "lang": lang})
+
+
 class TestParseIntentFile(unittest.TestCase):
     def _write(self, tmp, lines):
-        import os
         path = os.path.join(tmp, "demo.intent")
         with open(path, "w", encoding="utf-8") as fh:
             fh.write("\n".join(lines))
         return path
 
     def test_malformed_lines_skipped_valid_kept(self):
-        import tempfile
         with tempfile.TemporaryDirectory() as tmp:
-            path = self._write(tmp, [
-                "play {Medien}",          # invalid (uppercase) slot name
-                "weather in {location",   # truncated brace
-                "{first}{second}",        # adjacent slots
-                "[UNUSED] noise",         # bracketed marker (valid optional)
-                "play {media}",
-                "(start|begin) {media}",
-            ])
-            sentences = _parse_intent_file(path)
+            path = self._write(tmp, MALFORMED + VALID)
+            with patch("ovos_m2v_pipeline.LOG.warning") as warn:
+                sentences = _parse_intent_file(path, "[ctx]")
         self.assertIn("play {media}", sentences)
         self.assertIn("start {media}", sentences)
         self.assertIn("begin {media}", sentences)
@@ -65,36 +73,142 @@ class TestParseIntentFile(unittest.TestCase):
         self.assertNotIn("play {Medien}", sentences)
         self.assertNotIn("weather in {location", sentences)
         self.assertNotIn("{first}{second}", sentences)
+        # one WARN per skipped template, carrying the caller's ctx fields
+        self.assertEqual(warn.call_count, len(MALFORMED))
+        for call in warn.call_args_list:
+            self.assertIn("skipping malformed template", call[0][0])
+            self.assertIn("[ctx]", call[0][0])
 
     def test_all_malformed_yields_empty(self):
-        import tempfile
         with tempfile.TemporaryDirectory() as tmp:
-            path = self._write(tmp, ["{Medien}", "{oops", "{a}{b}"])
-            self.assertEqual(_parse_intent_file(path), [])
+            path = self._write(tmp, MALFORMED)
+            with patch("ovos_m2v_pipeline.LOG.warning"):
+                self.assertEqual(_parse_intent_file(path), [])
 
 
-class TestRegisterPadatiousInlineSamples(unittest.TestCase):
-    def test_mixed_samples_register_valid_ones(self):
+class TestRegisterPadatious(unittest.TestCase):
+    def test_mixed_samples_register_valid_ones_with_field_warns(self):
         pipeline = _make_prototype_pipeline()
-        msg = Message("padatious:register_intent", data={
-            "name": "test_skill:demo.intent",
-            "samples": ["play {Medien}", "tune to {station",
-                        "{a}{b}", "play {media}"],
-        })
-        pipeline._handle_register_padatious(msg)
+        with patch("ovos_m2v_pipeline.LOG.warning") as warn:
+            pipeline._handle_register_padatious(
+                _padatious_msg(MALFORMED + VALID))
         self.assertIn("test_skill:demo.intent", pipeline.intents)
-        args = pipeline.prototype_store.add.call_args
-        self.assertEqual(args[0][2], ["play {media}"])
+        pipeline.prototype_store.add.assert_called_once()
+        sentences = pipeline.prototype_store.add.call_args[0][2]
+        self.assertIn("play {media}", sentences)
+        self.assertNotIn("play {Medien}", sentences)
+        self.assertEqual(warn.call_count, len(MALFORMED))
+        for call in warn.call_args_list:
+            log = call[0][0]
+            self.assertIn("skipping malformed template", log)
+            for field in FIELDS + ["test_skill:demo.intent",
+                                   "padatious:register_intent"]:
+                self.assertIn(field, log)
 
-    def test_malformed_only_does_not_raise_or_register(self):
+    def test_all_malformed_rejects_registration_with_warn(self):
         pipeline = _make_prototype_pipeline()
-        msg = Message("padatious:register_intent", data={
-            "name": "test_skill:demo.intent",
-            "samples": ["{Medien}", "{loc", "{a}{b}"],
-        })
-        pipeline._handle_register_padatious(msg)
+        with patch("ovos_m2v_pipeline.LOG.warning") as warn:
+            pipeline._handle_register_padatious(_padatious_msg(list(MALFORMED)))
         self.assertNotIn("test_skill:demo.intent", pipeline.intents)
         pipeline.prototype_store.add.assert_not_called()
+        rejection = warn.call_args_list[-1][0][0]
+        self.assertIn("rejecting registration", rejection)
+        self.assertIn("no valid template remains", rejection)
+        for field in FIELDS:
+            self.assertIn(field, rejection)
+
+    def test_malformed_file_skips_lines_keeps_valid(self):
+        pipeline = _make_prototype_pipeline()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "demo.intent")
+            with open(path, "w", encoding="utf-8") as fh:
+                fh.write("\n".join(MALFORMED + VALID))
+            msg = Message("padatious:register_intent",
+                          data={"name": "test_skill:demo.intent",
+                                "skill_id": "test_skill", "lang": "en-US",
+                                "file_name": path})
+            with patch("ovos_m2v_pipeline.LOG.warning") as warn:
+                pipeline._handle_register_padatious(msg)
+        self.assertIn("test_skill:demo.intent", pipeline.intents)
+        pipeline.prototype_store.add.assert_called_once()
+        for call in warn.call_args_list:
+            for field in FIELDS:
+                self.assertIn(field, call[0][0])
+
+    def test_rejected_lang_does_not_affect_other_langs(self):
+        # each registration message is per-lang: an all-malformed de-DE
+        # registration must not block the valid en-US one
+        pipeline = _make_prototype_pipeline()
+        with patch("ovos_m2v_pipeline.LOG.warning"):
+            pipeline._handle_register_padatious(
+                _padatious_msg(["spiele {Medien}"], lang="de-DE"))
+        pipeline.prototype_store.add.assert_not_called()
+        pipeline._handle_register_padatious(
+            _padatious_msg(list(VALID), lang="en-US"))
+        self.assertIn("test_skill:demo.intent", pipeline.intents)
+        pipeline.prototype_store.add.assert_called_once()
+
+
+class TestIntent4Registration(unittest.TestCase):
+    def _template_msg(self, samples, lang="en-US"):
+        return Message("ovos.intent.register.template",
+                       data={"skill_id": "test_skill",
+                             "intent_name": "demo",
+                             "lang": lang, "samples": samples})
+
+    def test_malformed_template_skipped_valid_indexed(self):
+        pipeline = _make_prototype_pipeline()
+        with patch("ovos_m2v_pipeline.LOG.warning") as warn:
+            pipeline._handle_intent4_register_template(
+                self._template_msg(MALFORMED + VALID))
+        pipeline.prototype_store.add.assert_called_once()
+        expanded = pipeline.prototype_store.add.call_args[0][2]
+        self.assertIn("play {media}", expanded)
+        self.assertNotIn("play {Medien}", expanded)
+        self.assertEqual(warn.call_count, len(MALFORMED))
+        for call in warn.call_args_list:
+            log = call[0][0]
+            self.assertIn("skipping malformed template", log)
+            for field in FIELDS + ["'demo'"]:
+                self.assertIn(field, log)
+
+    def test_all_malformed_rejected_with_warn(self):
+        pipeline = _make_prototype_pipeline()
+        with patch("ovos_m2v_pipeline.LOG.warning") as warn:
+            pipeline._handle_intent4_register_template(
+                self._template_msg(list(MALFORMED)))
+        pipeline.prototype_store.add.assert_not_called()
+        rejection = warn.call_args_list[-1][0][0]
+        self.assertIn("rejecting", rejection)
+        for field in FIELDS + ["'demo'"]:
+            self.assertIn(field, rejection)
+
+    def test_malformed_entity_sample_skipped_valid_indexed(self):
+        pipeline = _make_prototype_pipeline()
+        msg = Message("ovos.entity.register",
+                      data={"skill_id": "test_skill",
+                            "entity_name": "media",
+                            "lang": "en-US",
+                            "samples": ["spotify", "{bad"]})
+        with patch("ovos_m2v_pipeline.LOG.warning") as warn:
+            pipeline._handle_intent4_register_entity(msg)
+        self.assertEqual(pipeline.entities.get("media"), ["spotify"])
+        warn.assert_called_once()
+        self.assertIn("skipping malformed entity sample", warn.call_args[0][0])
+
+    def test_all_malformed_entity_samples_rejected(self):
+        pipeline = _make_prototype_pipeline()
+        msg = Message("ovos.entity.register",
+                      data={"skill_id": "test_skill",
+                            "entity_name": "media",
+                            "lang": "en-US",
+                            "samples": ["{bad", "{Worse}"]})
+        with patch("ovos_m2v_pipeline.LOG.warning") as warn:
+            pipeline._handle_intent4_register_entity(msg)
+        self.assertNotIn("media", pipeline.entities)
+        rejection = warn.call_args_list[-1][0][0]
+        self.assertIn("rejecting", rejection)
+        self.assertIn("no valid entity sample remains", rejection)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Per OVOS-INTENT-4 §6.3, a consuming plugin skips individual malformed templates and indexes the remaining valid ones, rejecting the registration only when no valid template remains. §5.3 fixes the WARN-log fields: `skill_id`, intent name, `lang`, the rejecting topic, and a one-line reason — the producer's only debugging signal on a fire-and-forget bus.

## Changes
- `_parse_intent_file` and the Padatious inline-samples path log each skipped template with the full §5.3 field set; a registration with zero valid templates logs an explicit `rejecting registration: no valid template remains` WARN.
- INTENT-4 template registration (`ovos.intent.register.template`): an unparsable template is skipped with a §5.3 WARN instead of being embedded as a raw string; the existing zero-valid rejection (§6.3) is unchanged.
- INTENT-4 entity registration (`ovos.entity.register`): an unparsable entry is skipped with a §5.3 WARN instead of being indexed verbatim; a registration with no valid entry remaining is rejected (§7.2).
- Regression tests assert the field set on every skip WARN, valid-item indexing alongside malformed items, all-malformed rejection for intents and entities, and per-lang registration isolation.

## Testing
Full test suite in a fresh uv venv: 150 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)