### PR TITLE
fix: warn when the frozen classifier receives INTENT-4 registrations it cannot match

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,35 @@ In your `mycroft.conf`:
 
 ---
 
+## 🧩 Which entrypoint do I want?
+
+This plugin ships two `opm.pipeline` entrypoints, backed by the same
+`Model2VecIntentPipeline` class but running in different modes:
+
+* **`ovos-m2v-pipeline`** (`Model2VecIntentPipeline`, `mode: "classifier"`, the
+  default) loads a pretrained, **frozen** classification head with a fixed
+  label set baked in at training time. It is fast and needs no runtime
+  fitting, but it can only ever return the labels it was trained on. It still
+  tracks OVOS-INTENT-4 `ovos.intent.register.template` registrations from
+  skills so it can gate/allowlist a trained label, but registering a new
+  intent that was not part of training does **not** teach it to that skill —
+  it will never be matched.
+* **`ovos-m2v-prototype-pipeline`** (`Model2VecPrototypePipeline`, `mode:
+  "prototype"`) loads a bare embedding model with no classification head and
+  builds its label set entirely at runtime, from the example utterances
+  supplied by Adapt/Padatious registrations and OVOS-INTENT-4 template
+  registrations. Use this entrypoint whenever skills need to register new
+  intents (including custom/dynamically-created skills) that must actually be
+  matched.
+
+Both entrypoints can be enabled together — configure each independently under
+its own `intents.<entrypoint-name>` key (see `Model2VecPrototypePipeline`
+docstring for an example) — so a deployment can keep the fast frozen
+classifier for its core trained intents while the prototype matcher picks up
+everything else.
+
+---
+
 ## 🧠 Usage
 
 The `Model2VecIntentPipeline` class integrates with the OVOS intent system. It:

--- a/ovos_m2v_pipeline/__init__.py
+++ b/ovos_m2v_pipeline/__init__.py
@@ -350,6 +350,10 @@ class Model2VecIntentPipeline(ConfidenceMatcherPipeline):
         #: utterance contains one of its label's blacklisted phrases. Named and
         #: matched consistently with the padacioso engine's ``excluded_keywords``.
         self.excluded_keywords: Dict[str, List[str]] = {}
+        #: skill_ids that already triggered the frozen-classifier INTENT-4
+        #: warning (see ``_handle_intent4_register_template``), so the
+        #: warning logs once per skill rather than once per template.
+        self._intent4_frozen_warned: set = set()
 
         mode = self.config.get("mode", "classifier")
 
@@ -682,6 +686,15 @@ class Model2VecIntentPipeline(ConfidenceMatcherPipeline):
 
         # Classifier mode is frozen: only gate the (already trained) label.
         if self.prototype_store is None:
+            skill_id = message.data.get("skill_id") or message.context.get("skill_id", "")
+            if skill_id and skill_id not in self._intent4_frozen_warned:
+                self._intent4_frozen_warned.add(skill_id)
+                LOG.warning(
+                    "Model2VecIntentPipeline is a frozen classifier and cannot "
+                    "match registered skill intents; use "
+                    "ovos-m2v-prototype-pipeline-* to match INTENT-4 "
+                    f"registrations from {skill_id}"
+                )
             self.intents.add(label)
             self._store_context_gate(label, message)
             LOG.debug(f"Model2Vec: tracking INTENT-4 template label '{label}'")

--- a/tests/test_intent4.py
+++ b/tests/test_intent4.py
@@ -174,6 +174,38 @@ class TestIntent4TemplateRegistration(unittest.TestCase):
         self.assertIsNone(p.prototype_store)
 
 
+class TestIntent4FrozenClassifierWarning(unittest.TestCase):
+    """The frozen classifier warns (once per skill) that it accepted an
+    INTENT-4 template registration it can never match; the prototype matcher
+    never warns, since it actually consumes the registration."""
+
+    def _msg(self, skill_id="music.skill", intent_name="play_music"):
+        return Message(
+            SpecMessage.INTENT_REGISTER_TEMPLATE.value,
+            data={"skill_id": skill_id, "intent_name": intent_name,
+                  "lang": "en-US", "samples": ["play music"]},
+            context={"skill_id": skill_id},
+        )
+
+    def test_classifier_mode_warns_once_per_skill(self):
+        p = _make_classifier_pipeline()
+        with patch("ovos_m2v_pipeline.LOG.warning") as warn:
+            p._handle_intent4_register_template(self._msg(intent_name="play_music"))
+            p._handle_intent4_register_template(self._msg(intent_name="stop_music"))
+            p._handle_intent4_register_template(self._msg(skill_id="other.skill"))
+        self.assertEqual(warn.call_count, 2)
+        first_msg = warn.call_args_list[0].args[0]
+        self.assertIn("frozen classifier", first_msg)
+        self.assertIn("ovos-m2v-prototype-pipeline", first_msg)
+        self.assertIn("music.skill", first_msg)
+
+    def test_prototype_mode_never_warns(self):
+        p = _make_prototype_pipeline()
+        with patch("ovos_m2v_pipeline.LOG.warning") as warn:
+            p._handle_intent4_register_template(self._msg())
+        warn.assert_not_called()
+
+
 class TestIntent4EntityRegistration(unittest.TestCase):
     def test_entity_fills_template_slots(self):
         p = _make_prototype_pipeline()


### PR DESCRIPTION
## Summary

Live-found deployer trap: the default `Model2VecIntentPipeline` (entrypoint `ovos-m2v-pipeline`, `mode="classifier"`) is a **frozen classifier** with a fixed label set trained offline. It accepts OVOS-INTENT-4 `ovos.intent.register.template` registrations (used to gate an already-trained label) but can never learn or match a brand-new label at runtime — only `Model2VecPrototypePipeline` (entrypoint `ovos-m2v-prototype-pipeline`, `mode="prototype"`) embeds and matches custom intents from registrations. A deployer wiring `ovos-m2v-pipeline` into their pipeline config reasonably expects registered skill intents to match; they silently never do.

- Log a `WARNING` (once per `skill_id`, tracked in a seen-set) when the frozen classifier accepts an INTENT-4 template registration it cannot match, pointing at `ovos-m2v-prototype-pipeline-*` as the entrypoint to use instead. The prototype pipeline never emits this warning, since it actually consumes the registration.
- README: new section clarifying the two `opm.pipeline` entrypoint families (frozen classifier vs. runtime prototype matcher) and when to use each; both can be enabled together for a hybrid deployment.
- Unit tests asserting the warning fires exactly once per skill on the frozen classifier and never fires on the prototype pipeline.

## Test plan

- [x] `python -m pytest tests -q --ignore=tests/end2end` in a fresh `uv` venv (`--prerelease=allow`): **157 passed, 2 skipped** (same skip count as before this change; no regressions)
- [x] New tests: `test_classifier_mode_warns_once_per_skill`, `test_prototype_mode_never_warns` in `tests/test_intent4.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)