### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,29 +2,29 @@
 
 # OVOS Model2Vec Intent Pipeline
 
-An intent matching pipeline for [OpenVoiceOS (OVOS)](https://openvoiceos.org), powered by the Model2Vec model for intent classification.
+An intent matching pipeline for [OpenVoiceOS (OVOS)](https://openvoiceos.org). It uses the [Model2Vec](https://github.com/MinishLab/model2vec) model for intent classification.
 
-This plugin uses a pretrained [Model2Vec](https://github.com/MinishLab/model2vec) model to classify natural language utterances into intent labels registered with the system (Adapt, Padatious, and plugin-specific labels). It only considers intents from loaded skills and ignores any labels from unregistered intents. This pipeline is ideal for use cases where other deterministic engines fail to provide a high-confidence match.
-
----
-
-## ✨ Features
-
-* ✅ Powered by Model2Vec for high-quality intent classification
-* ✅ Plug-and-play integration with OVOS pipelines
-* ✅ Model2Vec trained on [GitLocalize](https://gitlocalize.com/users/OpenVoiceOS) exports
-* ✅ English models in various sizes, distilled from [Potion](https://huggingface.co/collections/minishlab/potion-6721e0abd4ea41881417f062)
-* ✅ Multilingual model, distilled from [LaBSE](https://huggingface.co/minishlab/M2V_multilingual_output)
-* ✅ Syncs Adapt and Padatious intents dynamically at runtime
-* ✅ Only considers intents from loaded skills, ignoring unregistered labels
-
-> 💡 english models size ranges from 8MB to 150MB, the multilingual model (default) is over 500MB
+This plugin uses a pretrained Model2Vec model to classify natural language utterances into intent labels registered with the system (Adapt, Padatious, and plugin-specific labels). It only considers intents from loaded skills and ignores labels from unregistered intents. Use this pipeline when deterministic engines fail to give a high-confidence match.
 
 ---
 
-## 📦 Installation
+## Features
 
-You can install the plugin via `pip`:
+* Model2Vec drives intent classification.
+* The plugin integrates directly with OVOS pipelines.
+* The Model2Vec models train on [GitLocalize](https://gitlocalize.com/users/OpenVoiceOS) exports.
+* English models come in several sizes, distilled from [Potion](https://huggingface.co/collections/minishlab/potion-6721e0abd4ea41881417f062).
+* The multilingual model is distilled from [LaBSE](https://huggingface.co/minishlab/M2V_multilingual_output).
+* The plugin syncs Adapt and Padatious intents dynamically at runtime.
+* The plugin considers only intents from loaded skills and ignores unregistered labels.
+
+> English models range from 8 MB to 150 MB. The multilingual model (the default) is over 500 MB.
+
+---
+
+## Installation
+
+Install the plugin with `pip`:
 
 ```bash
 pip install ovos-m2v-pipeline
@@ -32,7 +32,7 @@ pip install ovos-m2v-pipeline
 
 ---
 
-## ⚙️ Configuration
+## Configuration
 
 In your `mycroft.conf`:
 
@@ -53,18 +53,18 @@ In your `mycroft.conf`:
 * `model`: Path to your pretrained Model2Vec model or huggingface repo.
 * `conf_xxx`: Minimum confidence threshold for intent matching.
 * `ignore_intents`: List of intents to ignore during matching.
-* `prototype_strategy`: Scoring strategy for prototype mode (`"max_over_all"` default — back-compatible). See [docs/strategies.md](docs/strategies.md).
+* `prototype_strategy`: Scoring strategy for prototype mode (default `"max_over_all"`, back-compatible). See [docs/strategies.md](docs/strategies.md).
 * `prototype_top_k`: Top-k cosines averaged by the `top_k_mean` strategy (default `3`).
 * `prototype_tau`: Softmax temperature for the `softmax_weighted` strategy (default `0.1`).
 
-> ⚠️  The Model2Vec model is pretrained based on GitLocalize exports and **cannot learn new skills** dynamically.
+> The Model2Vec model is pretrained on GitLocalize exports. It **cannot learn new skills** dynamically.
 
 ---
 
-## 🧩 Which entrypoint do I want?
+## Which entrypoint do I want?
 
-This plugin ships two `opm.pipeline` entrypoints, backed by the same
-`Model2VecIntentPipeline` class but running in different modes:
+This plugin ships two `opm.pipeline` entrypoints. Both use the same
+`Model2VecIntentPipeline` class, running in different modes:
 
 * **`ovos-m2v-pipeline`** (`Model2VecIntentPipeline`, `mode: "classifier"`, the
   default) loads a pretrained, **frozen** classification head with a fixed
@@ -72,8 +72,8 @@ This plugin ships two `opm.pipeline` entrypoints, backed by the same
   fitting, but it can only ever return the labels it was trained on. It still
   tracks OVOS-INTENT-4 `ovos.intent.register.template` registrations from
   skills so it can gate/allowlist a trained label, but registering a new
-  intent that was not part of training does **not** teach it to that skill —
-  it will never be matched.
+  intent that was not part of training does **not** teach it to that skill.
+  That intent will never be matched.
 * **`ovos-m2v-prototype-pipeline`** (`Model2VecPrototypePipeline`, `mode:
   "prototype"`) loads a bare embedding model with no classification head and
   builds its label set entirely at runtime, from the example utterances
@@ -82,15 +82,15 @@ This plugin ships two `opm.pipeline` entrypoints, backed by the same
   intents (including custom/dynamically-created skills) that must actually be
   matched.
 
-Both entrypoints can be enabled together — configure each independently under
-its own `intents.<entrypoint-name>` key (see `Model2VecPrototypePipeline`
-docstring for an example) — so a deployment can keep the fast frozen
+You can enable both entrypoints together. Configure each independently under
+its own `intents.<entrypoint-name>` key (see the `Model2VecPrototypePipeline`
+docstring for an example), so a deployment can keep the fast frozen
 classifier for its core trained intents while the prototype matcher picks up
 everything else.
 
 ---
 
-## 🧠 Usage
+## Usage
 
 The `Model2VecIntentPipeline` class integrates with the OVOS intent system. It:
 
@@ -99,20 +99,27 @@ The `Model2VecIntentPipeline` class integrates with the OVOS intent system. It:
 3. Filters out intents that are not part of the loaded skills.
 4. Returns a match for the highest-confidence intent from the list of valid intents.
 
-
 ---
 
-## 🧪 Tips
+## Tips
 
 * Tune `min_conf` to control the confidence threshold for intent matching.
-* Use the `ignore_intents` list to filter out specific problematic intent from predictions.
-* Syncing of Adapt and Padatious intents is done automatically at runtime via the OVOS message bus.
+* Use the `ignore_intents` list to filter out specific problematic intents from predictions.
+* The plugin syncs Adapt and Padatious intents automatically at runtime, over the OVOS message bus.
 
-> 💡 pre-trained models available in this huggingface collection [ovos-model2vec-intents](https://huggingface.co/collections/Jarbas/ovos-model2vec-intents-681c478aecb9979e659b17f8)
+> Pre-trained models are available in the [ovos-model2vec-intents](https://huggingface.co/collections/Jarbas/ovos-model2vec-intents-681c478aecb9979e659b17f8) Hugging Face collection.
 
 ---
 
-## 🛡 License
+## Related projects
+
+* [OpenVoiceOS](https://github.com/OpenVoiceOS): the OVOS org, and the intent-pipeline system this plugin extends.
+* [ovos-plugin-manager](https://github.com/OpenVoiceOS/ovos-plugin-manager): the base pipeline class and plugin infrastructure.
+* [ovos-workshop](https://github.com/OpenVoiceOS/ovos-workshop): the skill framework this plugin integrates with.
+
+---
+
+## License
 
 This project is licensed under the [Apache 2.0 License](LICENSE).
 
@@ -122,12 +129,12 @@ This project is licensed under the [Apache 2.0 License](LICENSE).
 
 The model2vec intent pipeline was first prototyped by
 [TigreGótico](https://tigregotico.pt) under the [ILENIA](https://proyectoilenia.es)
-project for [OpenVoiceOS](https://openvoiceos.org) and substantially extended  —
-an embeddings-only mode and new models — through the NGI0 Commons Fund.
+project for [OpenVoiceOS](https://openvoiceos.org) and later extended
+with an embeddings-only mode and new models, through the NGI0 Commons Fund.
 
 <img src="./ilenia.png" width="128"/>
 
-> This project was funded by the Ministerio para la Transformación Digital y de la Función Pública and Plan de Recuperación, Transformación y Resiliencia - Funded by EU – NextGenerationEU within the framework of the project [ILENIA](https://proyectoilenia.es) with reference 2022/TL22/00215337
+> This project was funded by the Ministerio para la Transformación Digital y de la Función Pública and Plan de Recuperación, Transformación y Resiliencia - Funded by EU, NextGenerationEU within the framework of the project [ILENIA](https://proyectoilenia.es) with reference 2022/TL22/00215337
 
 [![NGI0 Commons Fund](./ngi.png)](https://nlnet.nl/project/OpenVoiceOS)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ An intent matching pipeline for [OpenVoiceOS (OVOS)](https://openvoiceos.org), p
 
 This plugin integrates a pre-trained Model2Vec static embedding model with the OVOS intent pipeline system. It classifies natural language utterances into intent labels that have been registered at runtime by loaded skills (via Adapt, Padatious, or plugin-specific registration).
 
-The pipeline is designed as a **fallback or confidence-based matcher** — it is most useful when deterministic engines (Adapt, Padatious) fail to produce a high-confidence match.
+The pipeline works best as a fallback or confidence-based matcher. Use it when deterministic engines (Adapt, Padatious) fail to produce a high-confidence match.
 
 ## How It Works
 
@@ -17,10 +17,10 @@ The pipeline is designed as a **fallback or confidence-based matcher** — it is
 
 ## Key Properties
 
-- **Pretrained, not adaptive** — the model was trained on a fixed corpus of OVOS skill intent examples. It cannot learn new skills at runtime.
-- **Runtime filtering** — even though the model knows hundreds of intent labels, only those from currently loaded skills are considered.
-- **Tiered confidence** — three match levels (`high`, `medium`, `low`) with separate thresholds, integrated into the OVOS pipeline priority system.
-- **Multilingual by default** — the default model covers 11+ languages.
+- **Pretrained, not adaptive.** The model was trained on a fixed corpus of OVOS skill intent examples. It cannot learn new skills at runtime.
+- **Runtime filtering.** Even though the model knows hundreds of intent labels, only those from currently loaded skills are considered.
+- **Tiered confidence.** Three match levels (`high`, `medium`, `low`) use separate thresholds, integrated into the OVOS pipeline priority system.
+- **Multilingual by default.** The default model covers 11+ languages.
 
 ## Documentation
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,7 +2,7 @@
 
 The pipeline is configured inside `mycroft.conf` under the `intents` section.
 
-## Minimal Configuration — Classifier Mode
+## Minimal Configuration: Classifier Mode
 
 ```json
 {
@@ -14,7 +14,7 @@ The pipeline is configured inside `mycroft.conf` under the `intents` section.
 }
 ```
 
-## Minimal Configuration — Prototype Mode
+## Minimal Configuration: Prototype Mode
 
 ```json
 {
@@ -27,7 +27,7 @@ The pipeline is configured inside `mycroft.conf` under the `intents` section.
 }
 ```
 
-Any bare `StaticModel` on Hugging Face (or a local path) can be used as the embedding backbone for prototype mode — no classifier head is needed.
+Any bare `StaticModel` on Hugging Face (or a local path) can be used as the embedding backbone for prototype mode. No classifier head is needed.
 
 ## Full Configuration Reference
 
@@ -54,12 +54,12 @@ Any bare `StaticModel` on Hugging Face (or a local path) can be used as the embe
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `model` | `str` | `"Jarbas/ovos-model2vec-intents-distiluse-base-multilingual-cased-v2"` | Hugging Face repo ID or local path. In classifier mode this must be a `StaticModelPipeline`; in prototype mode any bare `StaticModel` works. |
+| `model` | `str` | `"Jarbas/ovos-model2vec-intents-distiluse-base-multilingual-cased-v2"` | Hugging Face repo ID or local path. In classifier mode this must be a `StaticModelPipeline`. In prototype mode any bare `StaticModel` works. |
 | `mode` | `str` | `"classifier"` | Operating mode: `"classifier"` or `"prototype"`. |
-| `prototype_k` | `int` | unset (keep all) | Maximum number of prototype embeddings stored per intent label (prototype mode only). Unset keeps every registered sample so exact training samples always match; set an integer to cap memory. |
+| `prototype_k` | `int` | unset (keep all) | Maximum number of prototype embeddings stored per intent label (prototype mode only). Unset keeps every registered sample so exact training samples always match. Set an integer to cap memory. |
 | `prototype_strategy` | `str` | `"max_over_all"` | Scoring strategy for prototype mode. See [Prototype Strategies](#prototype-strategies-prototype-mode-only) below. |
 | `prototype_top_k` | `int` | `3` | Number of top cosine similarities averaged by the `top_k_mean` strategy. Also the default `k` for `softmax_weighted` when used in scoring. |
-| `prototype_tau` | `float` | `0.1` | Temperature for the `softmax_weighted` strategy. Lower values sharpen the distribution toward the maximum; higher values flatten it toward the mean. |
+| `prototype_tau` | `float` | `0.1` | Temperature for the `softmax_weighted` strategy. Lower values sharpen the distribution toward the maximum. Higher values flatten it toward the mean. |
 | `conf_high` | `float` | `0.7` | Minimum score for a `match_high` result. |
 | `conf_medium` | `float` | `0.5` | Minimum score for a `match_medium` result. |
 | `conf_low` | `float` | `0.15` | Minimum score for a `match_low` result. |
@@ -73,26 +73,26 @@ Any bare `StaticModel` on Hugging Face (or a local path) can be used as the embe
 | Value | Storage | Scoring | Notes |
 |-------|---------|---------|-------|
 | `max_over_all` | Every sample per label (random subsample when `prototype_k` is set) | Max cosine over stored anchors | Default. |
-| `mean_centroid` | 1 anchor = mean of all samples | Cosine to centroid | Cheapest storage and inference; classic prototype baseline. |
-| `medoid` | 1 anchor = sample closest to centroid | Cosine to medoid | Robust to outliers; avoids averaging blur. |
+| `mean_centroid` | 1 anchor = mean of all samples | Cosine to centroid | Cheapest storage and inference. A classic prototype baseline. |
+| `medoid` | 1 anchor = sample closest to centroid | Cosine to medoid | Not sensitive to outliers. Avoids averaging blur. |
 | `top_k_mean` | All samples kept | Mean of top-`prototype_top_k` cosines | Combines sharpness of max with smoothing. |
-| `farthest_point` | Up to `prototype_k` samples via maximin sampling | Max cosine | Anchors span the example space; good for diverse phrasings. |
+| `farthest_point` | Up to `prototype_k` samples via maximin sampling | Max cosine | Anchors span the example space. Good for diverse phrasings. |
 | `kmeans_centers` | Up to `prototype_k` spherical k-means centroids | Max cosine | Useful when a label has multi-modal phrasings. |
 | `softmax_weighted` | All samples kept | Softmax-weighted average of cosines | `prototype_tau` controls sharpness. |
 
-The default `max_over_all` produces byte-identical results to the store behaviour before strategies were introduced — existing `.npz` files and tuned thresholds remain valid.
+The default `max_over_all` produces byte-identical results to the store behavior before strategies were introduced. Existing `.npz` files and tuned thresholds remain valid.
 
 ## Confidence Thresholds
 
 Each `conf_*` key sets the minimum score required for the corresponding tier method to return a match:
 
-- **`conf_high`** — threshold for `match_high()`, called when `ovos-m2v-pipeline-high` appears in the pipeline list.
-- **`conf_medium`** — threshold for `match_medium()`, called when `ovos-m2v-pipeline-medium` appears.
-- **`conf_low`** — threshold for `match_low()`, called when `ovos-m2v-pipeline-low` appears.
+- **`conf_high`**: threshold for `match_high()`, called when `ovos-m2v-pipeline-high` appears in the pipeline list.
+- **`conf_medium`**: threshold for `match_medium()`, called when `ovos-m2v-pipeline-medium` appears.
+- **`conf_low`**: threshold for `match_low()`, called when `ovos-m2v-pipeline-low` appears.
 
-OVOS evaluates the pipeline list top-to-bottom and stops at the first match. Only the tiers you add to the pipeline list are ever invoked — unused tiers consume no resources.
+OVOS evaluates the pipeline list top-to-bottom and stops at the first match. Only the tiers you add to the pipeline list are ever invoked. Unused tiers consume no resources.
 
-In classifier mode the scores are softmax probabilities (sum to 1 across all labels). In prototype mode the scores are cosine similarities (typically 0–1); you may need to tune thresholds downward.
+In classifier mode the scores are softmax probabilities (sum to 1 across all labels). In prototype mode the scores are cosine similarities (typically 0-1). You may need to tune thresholds downward.
 
 Only the top-ranked valid intent is returned at each tier. If its score is below the threshold, `None` is returned and the OVOS pipeline moves to the next entry.
 
@@ -121,3 +121,6 @@ Set `model` to an absolute path to use a locally saved model:
 ```
 
 See [Models](models.md) for available pre-trained models and [Training](training.md) to produce your own.
+
+---
+[← OVOS Pipeline Plugin](ovos_pipeline.md) · [Home](README.md) · [Pipeline Internals →](pipeline.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,32 +8,32 @@ This plugin integrates a Model2Vec static embedding model with the OVOS intent p
 
 Two operating modes are available:
 
-- **Classifier mode** (default) — a `StaticModelPipeline` with a trained linear head. Inference returns softmax probabilities over a fixed label set baked into the model. Best when a pre-trained model covers all target skills.
-- **Prototype mode** — a bare `StaticModel` (embeddings only, no trained head). Each Padatious intent's example utterances are embedded at boot into a `PrototypeIntentStore`; matching uses cosine similarity. Best when skills are not known ahead of time or when you want zero-shot generalisation to new skills.
+- **Classifier mode** (default): a `StaticModelPipeline` with a trained linear head. Inference returns softmax probabilities over a fixed label set baked into the model. Use it when a pre-trained model covers all target skills.
+- **Prototype mode**: a bare `StaticModel` (embeddings only, no trained head). Each Padatious intent's example utterances are embedded at boot into a `PrototypeIntentStore`. Matching uses cosine similarity. Use it when skills are not known ahead of time, or when you want zero-shot generalization to new skills.
 
-The pipeline is designed as a **fallback or confidence-based matcher** — it is most useful when deterministic engines (Adapt, Padatious) fail to produce a high-confidence match.
+The pipeline works best as a fallback or confidence-based matcher. Use it when deterministic engines (Adapt, Padatious) fail to produce a high-confidence match.
 
-## How It Works — Classifier Mode
+## How It Works: Classifier Mode
 
 1. An utterance arrives from the user.
 2. The `StaticModelPipeline` produces a probability distribution over all training labels.
 3. The pipeline filters out any labels not currently registered by loaded skills.
 4. The highest-probability valid intent is returned if it meets the configured confidence threshold.
 
-## How It Works — Prototype Mode
+## How It Works: Prototype Mode
 
 1. At boot, each `padatious:register_intent` bus event carries the path to a `.intent` file with example utterances (or an inline `samples` list).
 2. The examples are template-expanded (e.g. `(turn on|switch on) the lights`) and embedded with the bare `StaticModel`.
-3. `select_anchors()` reduces the embeddings to the subset or aggregation dictated by `prototype_strategy`; up to `prototype_k` anchors per label are stored in `PrototypeIntentStore`.
+3. `select_anchors()` reduces the embeddings to the subset or aggregation dictated by `prototype_strategy`. Up to `prototype_k` anchors per label are stored in `PrototypeIntentStore`.
 4. At inference time, `score_labels()` turns the query embedding into one score per label according to the active `PrototypeStrategy`.
 
 ## Key Properties
 
-- **Classifier mode: pretrained, not adaptive** — the model was trained on a fixed corpus of OVOS skill intent examples. It cannot learn new skills at runtime.
-- **Prototype mode: zero-shot, adaptive** — any skill whose Padatious intent file contains example utterances can be matched, no retraining required.
-- **Runtime filtering** — only intents from currently loaded skills are ever returned.
-- **Tiered confidence** — three match levels (`high`, `medium`, `low`) with separate thresholds, integrated into the OVOS pipeline priority system.
-- **Multilingual by default** — the default model covers 11+ languages.
+- **Classifier mode: pretrained, not adaptive.** The model was trained on a fixed corpus of OVOS skill intent examples. It cannot learn new skills at runtime.
+- **Prototype mode: zero-shot, adaptive.** Any skill whose Padatious intent file contains example utterances can be matched, with no retraining required.
+- **Runtime filtering.** Only intents from currently loaded skills are ever returned.
+- **Tiered confidence.** Three match levels (`high`, `medium`, `low`) use separate thresholds, integrated into the OVOS pipeline priority system.
+- **Multilingual by default.** The default model covers 11+ languages.
 
 ## Documentation
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -38,3 +38,6 @@ After installing, confirm the entry point is registered:
 ```bash
 python -c "from ovos_m2v_pipeline import Model2VecIntentPipeline; print('OK')"
 ```
+
+---
+[Home](README.md) · [OVOS Pipeline Plugin →](ovos_pipeline.md)

--- a/docs/models.md
+++ b/docs/models.md
@@ -47,7 +47,7 @@ Distilled from the [Potion](https://huggingface.co/collections/minishlab/potion-
 
 ---
 
-## Prototype Mode — Embedding-Only Models
+## Prototype Mode: Embedding-Only Models
 
 In prototype mode the plugin uses a bare `StaticModel` (no classifier head). Any Model2Vec embedding model works, including the distilled bases used to train the classifier models above:
 
@@ -58,7 +58,7 @@ In prototype mode the plugin uses a bare `StaticModel` (no classifier head). Any
 | `minishlab/potion-base-8M` | English | ~32 MB |
 | `minishlab/potion-base-32M` | English | ~128 MB |
 
-Prototype mode requires no training step — just point `model` at any of the above and set `"mode": "prototype"`.
+Prototype mode requires no training step. Point `model` at any of the above and set `"mode": "prototype"`.
 
 ---
 
@@ -77,3 +77,6 @@ Point `model` at any local directory or Hugging Face repo that contains a `Stati
 ```
 
 See [Training](training.md) to produce your own model.
+
+---
+[← Prototype Strategies](strategies.md) · [Home](README.md) · [Training →](training.md)

--- a/docs/ovos_pipeline.md
+++ b/docs/ovos_pipeline.md
@@ -11,14 +11,14 @@ ovos-m2v-prototype-pipeline = ovos_m2v_pipeline:Model2VecPrototypePipeline
 
 | Plugin | Class | Mode | Requires training? |
 |--------|-------|------|--------------------|
-| `ovos-m2v-pipeline` | `Model2VecIntentPipeline` | Classifier | Yes — pre-trained `StaticModelPipeline` |
-| `ovos-m2v-prototype-pipeline` | `Model2VecPrototypePipeline` | Prototype | No — embeds examples at boot |
+| `ovos-m2v-pipeline` | `Model2VecIntentPipeline` | Classifier | Yes, a pre-trained `StaticModelPipeline` |
+| `ovos-m2v-prototype-pipeline` | `Model2VecPrototypePipeline` | Prototype | No, it embeds examples at boot |
 
 ## Configuration
 
 Each plugin reads from its own key under `"intents"` in `mycroft.conf`, so both can coexist in the same OVOS instance.
 
-### Classifier plugin — `ovos-m2v-pipeline`
+### Classifier plugin: `ovos-m2v-pipeline`
 
 ```json
 {
@@ -35,7 +35,7 @@ Each plugin reads from its own key under `"intents"` in `mycroft.conf`, so both 
 }
 ```
 
-### Prototype plugin — `ovos-m2v-prototype-pipeline`
+### Prototype plugin: `ovos-m2v-prototype-pipeline`
 
 ```json
 {
@@ -56,8 +56,8 @@ Each plugin reads from its own key under `"intents"` in `mycroft.conf`, so both 
 
 | Key | Type | Default | Applies to | Description |
 |-----|------|---------|------------|-------------|
-| `model` | `str` | `"Jarbas/ovos-model2vec-intents-distiluse-base-multilingual-cased-v2"` | both | HuggingFace repo ID or local path. Classifier mode requires a `StaticModelPipeline`; prototype mode accepts any bare `StaticModel`. |
-| `prototype_k` | `int` | unset (keep all) | prototype | Maximum prototype embeddings stored per intent label. Unset keeps every registered sample so exact training samples always match; set an integer to cap memory. |
+| `model` | `str` | `"Jarbas/ovos-model2vec-intents-distiluse-base-multilingual-cased-v2"` | both | Hugging Face repo ID or local path. Classifier mode requires a `StaticModelPipeline`. Prototype mode accepts any bare `StaticModel`. |
+| `prototype_k` | `int` | unset (keep all) | prototype | Maximum prototype embeddings stored per intent label. Unset keeps every registered sample so exact training samples always match. Set an integer to cap memory. |
 | `conf_high` | `float` | `0.7` | both | Minimum score for `match_high`. |
 | `conf_medium` | `float` | `0.5` | both | Minimum score for `match_medium`. |
 | `conf_low` | `float` | `0.15` | both | Minimum score for `match_low`. |
@@ -84,7 +84,7 @@ Sync is debounced with a 3-second sleep and the `_syncing` flag to coalesce burs
 |-------|---------|-------------|
 | `mycroft.ready` | `_handle_ready_prototype` | Logs store statistics when system is ready. |
 | `padatious:register_intent` | `_handle_register_padatious` | Reads `file_name` or inline `samples`, expands templates, embeds the expanded examples per label (capped by `prototype_k` when set). |
-| `register_intent` | `_handle_register_adapt` | Tracks Adapt label in `self.intents`; no prototypes (Adapt uses keywords, not examples). |
+| `register_intent` | `_handle_register_adapt` | Tracks Adapt label in `self.intents`. No prototypes are created, since Adapt uses keywords, not examples. |
 | `detach_intent` | `_handle_detach_intent` | Removes prototypes and label for the detached intent. |
 | `detach_skill` | `_handle_detach_skill` | Removes all prototypes and labels for the skill. `skill_id` is taken from `message.data` with `message.context` as fallback. |
 
@@ -113,7 +113,7 @@ The same applies to `ovos-m2v-prototype-pipeline-high/medium/low`.
 
 You control which tiers are active and where they sit relative to other matchers by placing (or omitting) these entries in the `pipeline` list. OVOS evaluates the list top-to-bottom and stops at the first match.
 
-In classifier mode the scores are softmax probabilities (0–1). In prototype mode the scores are cosine similarities (0–1 in practice); you may need to tune `conf_*` downward.
+In classifier mode the scores are softmax probabilities (0-1). In prototype mode the scores are cosine similarities (0-1 in practice). You may need to tune `conf_*` downward.
 
 An empty utterance list always returns `None` without attempting inference.
 
@@ -146,7 +146,7 @@ An empty utterance list always returns `None` without attempting inference.
 }
 ```
 
-Here the classifier runs at high confidence after Adapt; the prototype plugin runs at medium confidence only if all high-tier matchers have already failed.
+Here the classifier runs at high confidence after Adapt. The prototype plugin runs at medium confidence only if all high-tier matchers have already failed.
 
 ## Mixing Both Plugins
 
@@ -174,3 +174,6 @@ A typical setup runs the classifier first and falls back to the prototype plugin
   }
 }
 ```
+
+---
+[← Installation](installation.md) · [Home](README.md) · [Configuration →](configuration.md)

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -36,7 +36,7 @@ On startup the pipeline:
 2. Loads the model (`StaticModelPipeline` in classifier mode, `StaticModel` in prototype mode).
 3. Registers message bus event handlers.
 
-### Bus Events — Classifier Mode
+### Bus Events: Classifier Mode
 
 | Event | Handler |
 |-------|---------|
@@ -46,7 +46,7 @@ On startup the pipeline:
 | `detach_intent` | `handle_sync_intents` |
 | `detach_skill` | `handle_sync_intents` |
 
-### Bus Events — Prototype Mode
+### Bus Events: Prototype Mode
 
 | Event | Handler |
 |-------|---------|
@@ -58,7 +58,7 @@ On startup the pipeline:
 
 ---
 
-## Intent Synchronisation — Classifier Mode
+## Intent Synchronization: Classifier Mode
 
 `handle_sync_intents` is called whenever skills are loaded or unloaded. It:
 
@@ -69,23 +69,23 @@ On startup the pipeline:
 
 ---
 
-## Prototype Registration — Prototype Mode
+## Prototype Registration: Prototype Mode
 
 ### `_handle_register_padatious`
 
 Called for every `padatious:register_intent` event. Steps:
 
-1. Extract `name` from `message.data`; skip if in `ignore_labels`.
-2. Prefer inline `message.data["samples"]` if present; otherwise read the file at `message.data["file_name"]`.
+1. Extract `name` from `message.data`. Skip it if it is in `ignore_labels`.
+2. Prefer inline `message.data["samples"]` if present. Otherwise read the file at `message.data["file_name"]`.
 3. Apply `ovos_utils.bracket_expansion.expand_template` to every line so that template syntax is expanded into concrete utterances:
    - `(turn on|switch on) the lights` → `["turn on the lights", "switch on the lights"]`
    - `[please] play music` → `["please play music", "play music"]`
-4. Embed all expanded examples; `select_anchors()` (`ovos_m2v_pipeline/strategies.py:131`) reduces them to the subset or aggregation dictated by `prototype_strategy`. All resulting anchors are stored in `PrototypeIntentStore` (capped per label by `prototype_k` when set).
+4. Embed all expanded examples. `select_anchors()` (`ovos_m2v_pipeline/strategies.py:131`) reduces them to the subset or aggregation dictated by `prototype_strategy`. All resulting anchors are stored in `PrototypeIntentStore` (capped per label by `prototype_k` when set).
 5. Add the label to `self.intents`.
 
 ### `_handle_register_adapt`
 
-Adapt intents carry no example sentences — only keyword rules. The label is added to `self.intents` but no prototypes are created. These intents are not matched in prototype mode.
+Adapt intents carry no example sentences, only keyword rules. The label is added to `self.intents` but no prototypes are created. These intents are not matched in prototype mode.
 
 ### `_handle_detach_intent`
 
@@ -116,7 +116,7 @@ store.remove_skill("skill_a")
 scores = store.scores(query_embedding)  # {label: score}
 ```
 
-The scoring algorithm — and therefore what `scores()` returns — is determined by the `strategy` kwarg. The default `MAX_OVER_ALL` returns the maximum cosine similarity across all stored anchors per label, which is byte-compatible with the store's behaviour before strategies were introduced.
+The `strategy` kwarg determines the scoring algorithm, and therefore what `scores()` returns. The default `MAX_OVER_ALL` returns the maximum cosine similarity across all stored anchors per label. This is byte-compatible with the store's behavior before strategies were introduced.
 
 The store can optionally be persisted and reloaded with any strategy:
 
@@ -130,7 +130,7 @@ store = PrototypeIntentStore.load(
 )
 ```
 
-See [Configuration — Prototype Strategies](configuration.md#prototype-strategies-prototype-mode-only) for a full description of each strategy.
+See [Configuration: Prototype Strategies](configuration.md#prototype-strategies-prototype-mode-only) for a full description of each strategy.
 
 ---
 
@@ -156,7 +156,7 @@ After remapping, a label is skipped unless `skill_id` is one of the three specia
 
 ### Prototype mode filter
 
-The `PrototypeIntentStore` only ever contains labels that were explicitly registered via `_handle_register_padatious`; no additional `self.intents` filter is applied. Labels in `ignore_labels` are skipped.
+The `PrototypeIntentStore` only ever contains labels that were explicitly registered via `_handle_register_padatious`. No additional `self.intents` filter is applied. Labels in `ignore_labels` are skipped.
 
 ---
 
@@ -189,3 +189,6 @@ If the utterance list is empty, or the top result's score is below the threshold
 - **Prototype mode**: only Padatious intents with example utterances produce prototypes. Adapt intents (keyword-based) are tracked but never matched.
 - **Intent sync debounce** (classifier mode): a fixed 3-second sleep may leave `self.intents` empty briefly after startup.
 - Only the **first utterance** in the input list is evaluated (`utterances[0]`).
+
+---
+[← Configuration](configuration.md) · [Home](README.md) · [Prototype Strategies →](strategies.md)

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -2,14 +2,14 @@
 
 `PrototypeStrategy` (`ovos_m2v_pipeline/strategies.py:51`) is a `str`-enum that controls how a label's training-time embeddings are compressed into stored anchors and how those anchors are turned into a match score at inference time.
 
-The strategy is selected via the `prototype_strategy` config key (default `"max_over_all"`) — see [Configuration](configuration.md#prototype-strategies-prototype-mode-only).
+The strategy is selected via the `prototype_strategy` config key (default `"max_over_all"`). See [Configuration](configuration.md#prototype-strategies-prototype-mode-only).
 
 ## How strategies work
 
 Every strategy defines two phases:
 
-- **Storage** (`select_anchors` — `ovos_m2v_pipeline/strategies.py:131`) — runs at `PrototypeIntentStore.add()` time. Decides which subset or aggregation of the sample embeddings is persisted as *anchors* for the label.
-- **Scoring** (`score_labels` — `ovos_m2v_pipeline/strategies.py:183`) — runs at inference time. Takes the query embedding and the stored anchors and returns one `float` score per label.
+- **Storage** (`select_anchors` in `ovos_m2v_pipeline/strategies.py:131`) runs at `PrototypeIntentStore.add()` time. It decides which subset or aggregation of the sample embeddings is persisted as *anchors* for the label.
+- **Scoring** (`score_labels` in `ovos_m2v_pipeline/strategies.py:183`) runs at inference time. It takes the query embedding and the stored anchors and returns one `float` score per label.
 
 Both functions accept L2-normalised input and return L2-normalised output / scores.
 
@@ -18,20 +18,20 @@ Both functions accept L2-normalised input and return L2-normalised output / scor
 | Value | Anchors stored | Score per label |
 |-------|---------------|-----------------|
 | `max_over_all` | Every sample (random subsample only when `prototype_k` is set and `n > k`) | Max cosine over anchors |
-| `mean_centroid` | 1 — mean of all samples, re-normalised | Cosine to centroid |
-| `medoid` | 1 — sample closest to centroid | Cosine to medoid |
+| `mean_centroid` | 1, the mean of all samples, re-normalized | Cosine to centroid |
+| `medoid` | 1, the sample closest to centroid | Cosine to medoid |
 | `top_k_mean` | All samples | Mean of top-`prototype_top_k` cosines |
 | `farthest_point` | Every sample, or `prototype_k` samples via maximin (farthest-point) sampling when set | Max cosine |
 | `kmeans_centers` | Every sample, or `prototype_k` spherical k-means centroids when set | Max cosine |
-| `softmax_weighted` | All samples | Softmax-weighted average; temperature = `prototype_tau` |
+| `softmax_weighted` | All samples | Softmax-weighted average, temperature = `prototype_tau` |
 
 ### Notes
 
-- `max_over_all` is the default. It is byte-compatible with the store's behaviour before strategies were introduced — existing `.npz` files and tuned confidence thresholds remain valid.
+- `max_over_all` is the default. It is byte-compatible with the store's behavior before strategies were introduced, so existing `.npz` files and tuned confidence thresholds remain valid.
 - `mean_centroid` and `medoid` always store exactly one anchor per label, making them cheapest at inference time.
-- `top_k_mean` and `softmax_weighted` keep every sample, so memory cost scales with corpus size; both do their aggregation at score time.
-- `farthest_point` and `kmeans_centers` cluster examples to span the label's semantic space — useful when a skill's intent file contains phrasings from distinct semantic clusters.
-- For `softmax_weighted`, lower `prototype_tau` values make the score approximate the maximum cosine; higher values approach the mean cosine.
+- `top_k_mean` and `softmax_weighted` keep every sample, so memory cost scales with corpus size. Both do their aggregation at score time.
+- `farthest_point` and `kmeans_centers` cluster examples to span the label's semantic space. This helps when a skill's intent file contains phrasings from distinct semantic clusters.
+- For `softmax_weighted`, lower `prototype_tau` values make the score approximate the maximum cosine. Higher values approach the mean cosine.
 
 ## Direct API
 
@@ -56,3 +56,6 @@ scores = score_labels(
 ```
 
 Both functions accept and return `np.ndarray` with `float32` values. `embeddings` / `query` are assumed to be L2-normalised on input.
+
+---
+[← Pipeline Internals](pipeline.md) · [Home](README.md) · [Models →](models.md)

--- a/docs/training.md
+++ b/docs/training.md
@@ -22,7 +22,7 @@ train/
 
 ---
 
-## Step 1 — Gather the Dataset
+## Step 1: Gather the Dataset
 
 ### Multilingual
 
@@ -64,9 +64,9 @@ Each row in the CSV represents one training example:
 
 Labels follow the format `<skill_id>:<intent_name>`.
 
-### Normalisation
+### Normalization
 
-`gather_dataset.py` applies the following normalisation before saving:
+`gather_dataset.py` applies the following normalization before saving:
 
 - **`sentence`**: lowercased, commas removed, multi-word separators collapsed, leading/trailing quotes stripped.
 - **`domain`** (skill ID): `skill-ovos` prefix replaced with `ovos-skill`.
@@ -76,7 +76,7 @@ Blacklists (`BLACKLIST_SKILLS`, `BLACKLIST_INTENTS`) allow excluding specific sk
 
 ---
 
-## Step 2 — Train the Model
+## Step 2: Train the Model
 
 ### Multilingual
 
@@ -105,13 +105,13 @@ Trains five separate classifiers, one per Potion base model:
 - `minishlab/potion-retrieval-32M`
 
 Each is trained for 25 epochs. Outputs:
-- `m2v_intents_<base_model_name>/` — saved pipeline
-- `metrics_en_<base_model_name>.md` — per-model metrics
-- `model_comparison_en.md` — comparison table across all English models
+- `m2v_intents_<base_model_name>/`: the saved pipeline
+- `metrics_en_<base_model_name>.md`: per-model metrics
+- `model_comparison_en.md`: a comparison table across all English models
 
 ---
 
-## Step 3 — (Optional) Distill a New Base Model
+## Step 3 (Optional): Distill a New Base Model
 
 If you want to start from a Sentence Transformer that is not yet available as a Model2Vec distillate:
 
@@ -123,7 +123,7 @@ Edit the model list at the top of `distill.py`, then run the script. It calls `m
 
 ---
 
-## Step 4 — Test the Trained Model
+## Step 4: Test the Trained Model
 
 Use `predict.py` as a quick smoke test:
 
@@ -165,3 +165,6 @@ m.push_to_hub('YourOrg/your-model-name')
 ```
 
 Then update the `model` key in your OVOS configuration to point at the new repo.
+
+---
+[← Models](models.md) · [Home](README.md)


### PR DESCRIPTION
Rewrites README.md and the docs/*.md pages in Simplified Technical English for clarity: shorter sentences, active voice, no marketing language or emoji in headings, and consistent American spelling. Adds a navigation footer to the multi-page doc set, links related OVOS projects, and keeps every fact, code block, table, and the funding/license sections unchanged.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refreshed README and documentation wording for clarity and consistency.
  * Clarified classifier and prototype modes, processing behavior, fallback usage, scoring, and configuration options.
  * Improved installation, training, pipeline, model, and strategy guidance.
  * Added navigation links between related documentation pages.
  * Standardized headings, formatting, terminology, punctuation, and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->