### PR TITLE
fix: keep model2vec encoding in-process

### DIFF
--- a/docs/prerelease-quirks.md
+++ b/docs/prerelease-quirks.md
@@ -1,0 +1,20 @@
+# Pre-release quirks
+
+Behavior changes since the last stable release, newest first. This file is
+reset at each stable release.
+
+## 0.5.5a1
+
+- Embedding runs strictly in-process: every `model.encode` call passes
+  `use_multiprocessing=False`. model2vec otherwise spawns `os.cpu_count()`
+  loky worker subprocesses for sentence batches over its threshold, which
+  inside a memory-capped service cgroup meant dozens of workers, deep swap
+  and an OOM-kill during skill loading on a real deployment. Large template
+  batches now encode sequentially — slightly slower for huge batches, never
+  a process fan-out.
+- Entity-filled template expansion is bounded: the cartesian product over a
+  template's registered entity values caps at 2000 combinations, sampled
+  deterministically and evenly across the space (endpoints kept). Two
+  ~2200-value entities in one template previously materialized ~4.8M
+  strings and embedded them all on every registration — tens of GB of swap
+  and an OOM-kill on a real deployment.

--- a/ovos_m2v_pipeline/__init__.py
+++ b/ovos_m2v_pipeline/__init__.py
@@ -39,6 +39,14 @@ _SPECIAL_LABEL_PIPELINES = {
 }
 
 
+#: Upper bound on entity-filled samples generated per template. The
+#: cartesian product over registered entity values is unbounded input
+#: (auto-registered .entity files can carry thousands of values each);
+#: everything past this bound is a deterministic evenly-strided sample of
+#: the combination space.
+MAX_ENTITY_EXPANSIONS = 2000
+
+
 class PrototypeIntentStore:
     """Mutable store of L2-normalised prototype embeddings per intent label.
 
@@ -137,7 +145,14 @@ class PrototypeIntentStore:
         # Embed every sample first; the strategy decides which / how many
         # to keep as anchors at storage time. Embedding happens outside the
         # lock: it is the expensive step and touches no shared state.
-        embs = np.atleast_2d(model.encode(list(sentences))).astype(np.float32)
+        # use_multiprocessing=False: model2vec otherwise spawns
+        # os.cpu_count() loky workers for batches over its threshold —
+        # observed as 24 subprocesses inside a 2G service cgroup, deep swap
+        # and an OOM-kill during skill loading. Static-model encoding is
+        # in-process numpy; a long-lived service never wants that fan-out.
+        embs = np.atleast_2d(
+            model.encode(list(sentences),
+                         use_multiprocessing=False)).astype(np.float32)
         norms = np.linalg.norm(embs, axis=1, keepdims=True)
         embs = np.where(norms > 0, embs / norms, embs)
         anchors = select_anchors(
@@ -657,7 +672,34 @@ class Model2VecIntentPipeline(ConfidenceMatcherPipeline):
             for slot in slots:
                 vals = self.entities.get(slot.lower())
                 slot_values.append(vals if vals else ["{" + slot + "}"])
-            for combo in itertools.product(*slot_values):
+            # the cartesian product over large value sets explodes: two
+            # ~2000-value entities in one template is ~4M strings, all
+            # materialized and embedded on every registration — enough to
+            # swap out and OOM-kill a capped service. Engines own bounding
+            # unbounded entity data: take a deterministic, evenly-strided
+            # sample of the combination space instead.
+            sizes = [len(v) for v in slot_values]
+            total = 1
+            for n in sizes:
+                total *= n
+            if total > MAX_ENTITY_EXPANSIONS:
+                LOG.warning(
+                    f"template {tmpl!r} expands to {total} combinations; "
+                    f"sampling {MAX_ENTITY_EXPANSIONS} evenly")
+                step = (total - 1) / (MAX_ENTITY_EXPANSIONS - 1)
+                indices = {round(i * step) for i in range(MAX_ENTITY_EXPANSIONS)}
+                combos = []
+                for idx in sorted(indices):
+                    combo = []
+                    rem = idx
+                    for n in reversed(sizes):
+                        combo.append(rem % n)
+                        rem //= n
+                    combos.append(tuple(slot_values[d][c] for d, c in
+                                        enumerate(reversed(combo))))
+            else:
+                combos = itertools.product(*slot_values)
+            for combo in combos:
                 filled = tmpl
                 for slot, val in zip(slots, combo):
                     filled = filled.replace("{" + slot + "}", val, 1)
@@ -956,7 +998,7 @@ class Model2VecIntentPipeline(ConfidenceMatcherPipeline):
         only forwarded when the matching downstream pipeline is present in the
         caller's session, consistent with classifier mode.
         """
-        emb = self.model.encode([utterance])[0]
+        emb = self.model.encode([utterance], use_multiprocessing=False)[0]
         label_scores = self.prototype_store.scores(emb)
         special = self._allowed_special_labels(message)
         for label, score in sorted(label_scores.items(), key=lambda x: x[1], reverse=True):

--- a/tests/test_encode_bounded.py
+++ b/tests/test_encode_bounded.py
@@ -1,0 +1,43 @@
+"""Embedding must stay in-process: model2vec spawns os.cpu_count() loky
+workers for large batches unless use_multiprocessing=False — observed as 24
+subprocesses inside a 2G service cgroup and an OOM-kill at skill load."""
+from unittest import mock
+
+import numpy as np
+
+from ovos_m2v_pipeline import PrototypeIntentStore
+
+
+def test_store_add_disables_multiprocessing():
+    store = PrototypeIntentStore()
+    model = mock.Mock()
+    model.encode.return_value = np.ones((2, 4), dtype=np.float32)
+    store.add(model, "label", ["a b", "c d"])
+    assert model.encode.called
+    _, kwargs = model.encode.call_args
+    assert kwargs.get("use_multiprocessing") is False
+
+
+def test_entity_expansion_is_bounded():
+    """Two large entities in one template must not materialize the full
+    cartesian product (observed: ~4.8M strings, 23G swap, OOM-kill)."""
+    from ovos_m2v_pipeline import MAX_ENTITY_EXPANSIONS, Model2VecIntentPipeline
+    p = Model2VecIntentPipeline.__new__(Model2VecIntentPipeline)
+    p.entities = {"mon": [f"mon{i}" for i in range(2200)],
+                  "move": [f"move{i}" for i in range(2200)]}
+    out = p._expand_entities(["can {mon} learn {move}"])
+    assert len(out) == MAX_ENTITY_EXPANSIONS
+    assert len(set(out)) == len(out)
+    # deterministic: same input, same sample
+    assert out == p._expand_entities(["can {mon} learn {move}"])
+    # endpoints of the combination space are kept
+    assert "can mon0 learn move0" in out
+    assert "can mon2199 learn move2199" in out
+
+
+def test_small_expansion_untouched():
+    from ovos_m2v_pipeline import Model2VecIntentPipeline
+    p = Model2VecIntentPipeline.__new__(Model2VecIntentPipeline)
+    p.entities = {"city": ["porto", "lisbon"]}
+    out = p._expand_entities(["weather in {city}"])
+    assert sorted(out) == ["weather in lisbon", "weather in porto"]

--- a/tests/test_exact_sample_match.py
+++ b/tests/test_exact_sample_match.py
@@ -12,7 +12,7 @@ from ovos_bus_client.message import Message
 from tests.test_pipeline import _make_prototype_pipeline
 
 
-def _hash_encode(sentences):
+def _hash_encode(sentences, **kwargs):
     """Deterministic bag-of-words hashing encoder.
 
     Identical sentences map to identical vectors (cosine 1.0); sentences

--- a/tests/test_intent4.py
+++ b/tests/test_intent4.py
@@ -22,7 +22,7 @@ def _make_prototype_pipeline(config=None):
 
     mock_embed_model = MagicMock()
     # identity rows so each sample becomes a distinct unit prototype
-    mock_embed_model.encode.side_effect = lambda sents: np.eye(len(sents), 4, dtype=np.float32)
+    mock_embed_model.encode.side_effect = lambda sents, **kw: np.eye(len(sents), 4, dtype=np.float32)
 
     fake_m2v = MagicMock()
     fake_m2v.StaticModel.from_pretrained.return_value = mock_embed_model

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -120,7 +120,7 @@ class TestPrototypeIntentStore(unittest.TestCase):
     def test_build_samples_k_per_label(self):
         from ovos_m2v_pipeline import PrototypeIntentStore
         mock_model = MagicMock()
-        mock_model.encode.side_effect = lambda sents: np.eye(len(sents), 4, dtype=np.float32)
+        mock_model.encode.side_effect = lambda sents, **kw: np.eye(len(sents), 4, dtype=np.float32)
 
         sentences = [f"sent_{i}" for i in range(20)]
         labels = ["a"] * 10 + ["b"] * 10
@@ -132,7 +132,7 @@ class TestPrototypeIntentStore(unittest.TestCase):
     def test_build_keeps_all_when_fewer_than_k(self):
         from ovos_m2v_pipeline import PrototypeIntentStore
         mock_model = MagicMock()
-        mock_model.encode.side_effect = lambda sents: np.eye(len(sents), 4, dtype=np.float32)
+        mock_model.encode.side_effect = lambda sents, **kw: np.eye(len(sents), 4, dtype=np.float32)
 
         sentences = ["only one"]
         labels = ["a"]
@@ -533,7 +533,7 @@ class TestMatchConfidence(unittest.TestCase):
 class TestPrototypeIntentStoreMutable(unittest.TestCase):
     def _mock_model(self, dim=4):
         m = MagicMock()
-        m.encode.side_effect = lambda sents: np.eye(len(sents), dim, dtype=np.float32)
+        m.encode.side_effect = lambda sents, **kw: np.eye(len(sents), dim, dtype=np.float32)
         return m
 
     def test_add_populates_empty_store(self):
@@ -662,7 +662,7 @@ class TestPrototypeBusHandlers(unittest.TestCase):
     def test_handle_register_padatious_adds_prototypes(self):
         p = self._pipeline()
         with patch("ovos_m2v_pipeline._parse_intent_file", return_value=["hello", "hi"]):
-            p.model.encode.side_effect = lambda sents: np.eye(len(sents), 4, dtype=np.float32)
+            p.model.encode.side_effect = lambda sents, **kw: np.eye(len(sents), 4, dtype=np.float32)
             p._handle_register_padatious(Message("padatious:register_intent", data={
                 "name": "skill_a:greet.intent",
                 "file_name": "/fake/greet.intent",
@@ -673,13 +673,13 @@ class TestPrototypeBusHandlers(unittest.TestCase):
     def test_handle_register_padatious_updates_existing_label(self):
         p = self._pipeline()
         with patch("ovos_m2v_pipeline._parse_intent_file", return_value=["v1"]):
-            p.model.encode.side_effect = lambda sents: np.eye(len(sents), 4, dtype=np.float32)
+            p.model.encode.side_effect = lambda sents, **kw: np.eye(len(sents), 4, dtype=np.float32)
             p._handle_register_padatious(Message("padatious:register_intent", data={
                 "name": "skill_a:greet.intent",
                 "file_name": "/fake/greet.intent",
             }))
         with patch("ovos_m2v_pipeline._parse_intent_file", return_value=["v2"]):
-            p.model.encode.side_effect = lambda sents: np.eye(len(sents), 4, dtype=np.float32)
+            p.model.encode.side_effect = lambda sents, **kw: np.eye(len(sents), 4, dtype=np.float32)
             p._handle_register_padatious(Message("padatious:register_intent", data={
                 "name": "skill_a:greet.intent",
                 "file_name": "/fake/greet.intent",
@@ -688,7 +688,7 @@ class TestPrototypeBusHandlers(unittest.TestCase):
 
     def test_handle_register_padatious_inline_samples(self):
         p = self._pipeline()
-        p.model.encode.side_effect = lambda sents: np.eye(len(sents), 4, dtype=np.float32)
+        p.model.encode.side_effect = lambda sents, **kw: np.eye(len(sents), 4, dtype=np.float32)
         p._handle_register_padatious(Message("padatious:register_intent", data={
             "name": "skill_a:greet.intent",
             "samples": ["hello", "hi"],
@@ -699,7 +699,7 @@ class TestPrototypeBusHandlers(unittest.TestCase):
     def test_handle_register_padatious_inline_samples_expand_template(self):
         """Inline samples with template syntax are expanded."""
         p = self._pipeline()
-        p.model.encode.side_effect = lambda sents: np.eye(len(sents), 4, dtype=np.float32)
+        p.model.encode.side_effect = lambda sents, **kw: np.eye(len(sents), 4, dtype=np.float32)
         p._handle_register_padatious(Message("padatious:register_intent", data={
             "name": "skill_a:lights.intent",
             "samples": ["(turn on|switch on) the lights"],
@@ -743,7 +743,7 @@ class TestPrototypeBusHandlers(unittest.TestCase):
     def test_handle_detach_intent_removes_prototypes_and_intents(self):
         p = self._pipeline()
         with patch("ovos_m2v_pipeline._parse_intent_file", return_value=["hello"]):
-            p.model.encode.side_effect = lambda sents: np.eye(len(sents), 4, dtype=np.float32)
+            p.model.encode.side_effect = lambda sents, **kw: np.eye(len(sents), 4, dtype=np.float32)
             p._handle_register_padatious(Message("padatious:register_intent", data={
                 "name": "skill_a:greet.intent",
                 "file_name": "/fake/greet.intent",
@@ -754,7 +754,7 @@ class TestPrototypeBusHandlers(unittest.TestCase):
 
     def test_handle_detach_skill_uses_context_skill_id(self):
         p = self._pipeline()
-        p.model.encode.side_effect = lambda sents: np.eye(len(sents), 4, dtype=np.float32)
+        p.model.encode.side_effect = lambda sents, **kw: np.eye(len(sents), 4, dtype=np.float32)
         with patch("ovos_m2v_pipeline._parse_intent_file", return_value=["hello"]):
             p._handle_register_padatious(Message("padatious:register_intent",
                                                  data={"name": "skill_a:intent", "file_name": "/fake/x.intent"}))
@@ -764,7 +764,7 @@ class TestPrototypeBusHandlers(unittest.TestCase):
 
     def test_handle_detach_skill_removes_all_skill_labels(self):
         p = self._pipeline()
-        p.model.encode.side_effect = lambda sents: np.eye(len(sents), 4, dtype=np.float32)
+        p.model.encode.side_effect = lambda sents, **kw: np.eye(len(sents), 4, dtype=np.float32)
         for name in ("skill_a:intent_x", "skill_a:intent_y"):
             with patch("ovos_m2v_pipeline._parse_intent_file", return_value=["example"]):
                 p._handle_register_padatious(Message("padatious:register_intent",

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -20,7 +20,7 @@ class _FakeModel:
     def __init__(self, dim: int = 16):
         self.dim = dim
 
-    def encode(self, sentences):
+    def encode(self, sentences, **kwargs):
         import hashlib
         out = []
         for s in sentences:


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

Two defects diagnosed on the same live deployment, fixed together because they compound in the same registration path. First: model2vec's `StaticModel.encode` spawns `os.cpu_count()` loky worker subprocesses whenever a sentence batch exceeds its multiprocessing threshold, and this plugin feeds it exactly such batches during INTENT-4 template registration at skill load. On a 24-core box under the skills service's 2G cgroup that meant 24 LokyProcess workers, tens of GB of swap and an OOM-kill ~34 minutes into loading. A box-side `LOKY_MAX_CPU_COUNT=2` override mitigates; this is the proper upstream fix.

Every `encode` call now passes `use_multiprocessing=False`: static-model embedding is in-process numpy, and a long-lived service should never inherit a per-batch process fan-out sized to the machine. Huge batches encode sequentially — marginally slower in the worst case, never a fork storm.

The tests' fake models pinned the old one-argument `encode` signature and are updated to accept keyword arguments (the real model2vec API does); a new test asserts the store's encode path passes the flag, fail-before verified. Full suite: 158 passed, 2 skipped. Docs: prerelease-quirks entry.



Second, the steady-state OOM (the box kept dying every 70-90 minutes even with workers bounded): `_expand_entities` materializes the full cartesian product of a template's entity values — two ~2200-value auto-registered entities in one template is ~4.8M filled strings, all embedded, on every registration cycle. The expansion now caps at 2000 combinations per template, sampled deterministically and evenly across the combination space with the endpoints kept, per the standing rule that engines bound unbounded entity data. Tests pin the bound, determinism, endpoint coverage, and that small expansions are untouched; fail-before verified. Full suite: 160 passed, 2 skipped.