### PR TITLE
fix: bound store ingest and dealias padatious labels

### DIFF
--- a/docs/prerelease-quirks.md
+++ b/docs/prerelease-quirks.md
@@ -3,6 +3,20 @@
 Behavior changes since the last stable release, newest first. This file is
 reset at each stable release.
 
+## 0.5.6a1
+
+- The sample bound applies at store ingest, whatever path materialized the
+  samples: the 2000-cap previously applied only to entity slot-filling, so
+  pre-expanded padatious registrations flowed in unbounded — a real
+  deployment still built a ~1.1M-prototype store on 0.5.5a1 and swapped its
+  cgroup to death. `PrototypeIntentStore.add` now evenly samples any batch
+  over the bound.
+- Padatious-contract labels are dealiased: the legacy `.intent`-suffixed
+  name folds onto the canonical suffixless label (registration, detach and
+  ignore_labels accept both forms), so the dual-emit from ovos-workshop no
+  longer stores every prototype twice, and matches dispatch on the same
+  canonical id padatious itself uses.
+
 ## 0.5.5a1
 
 - Embedding runs strictly in-process: every `model.encode` call passes

--- a/ovos_m2v_pipeline/__init__.py
+++ b/ovos_m2v_pipeline/__init__.py
@@ -142,6 +142,19 @@ class PrototypeIntentStore:
         """
         if not sentences:
             return 0
+        if len(sentences) > MAX_ENTITY_EXPANSIONS:
+            # single choke point: whatever path materialized the samples
+            # (entity slot-filling, padatious template expansion, inline
+            # payloads), the store never ingests an unbounded batch — the
+            # 2000-cap applied only on one expansion path let a real
+            # deployment build a million-prototype store and OOM its cgroup
+            LOG.warning(f"label {label!r}: {len(sentences)} samples exceed "
+                        f"the ingest bound; sampling {MAX_ENTITY_EXPANSIONS} "
+                        f"evenly")
+            step = (len(sentences) - 1) / (MAX_ENTITY_EXPANSIONS - 1)
+            keep = sorted({round(i * step)
+                           for i in range(MAX_ENTITY_EXPANSIONS)})
+            sentences = [sentences[i] for i in keep]
         # Embed every sample first; the strategy decides which / how many
         # to keep as anchors at storage time. Embedding happens outside the
         # lock: it is the expensive step and touches no shared state.
@@ -556,7 +569,13 @@ class Model2VecIntentPipeline(ConfidenceMatcherPipeline):
         and its template syntax is expanded via ``expand_template``.
         """
         name: str = message.data.get("name", "")
-        if not name or name in self.ignore_labels:
+        if name.endswith(".intent"):
+            # ovos-workshop dual-registers one intent on both wire contracts
+            # (legacy name suffixed ".intent", spec name suffixless); fold to
+            # one canonical label or the store holds every prototype twice
+            name = name[:-len(".intent")]
+        # ignore_labels entries may be written in either wire form
+        if not name or name in self.ignore_labels                 or f"{name}.intent" in self.ignore_labels:
             return
 
         skill_id = message.data.get("skill_id") or message.context.get("skill_id")
@@ -598,6 +617,9 @@ class Model2VecIntentPipeline(ConfidenceMatcherPipeline):
 
     def _handle_detach_intent(self, message: Message) -> None:
         name: str = message.data.get("intent_name", "")
+        if name.endswith(".intent"):
+            # mirror the registration-side dealiasing
+            name = name[:-len(".intent")]
         if name:
             self.prototype_store.remove(name)
             self.intents.discard(name)

--- a/tests/test_encode_bounded.py
+++ b/tests/test_encode_bounded.py
@@ -41,3 +41,49 @@ def test_small_expansion_untouched():
     p.entities = {"city": ["porto", "lisbon"]}
     out = p._expand_entities(["weather in {city}"])
     assert sorted(out) == ["weather in lisbon", "weather in porto"]
+
+
+def test_store_ingest_is_bounded_regardless_of_source():
+    """The cap must hold at the store, not one expansion path: real
+    deployments feed pre-expanded padatious samples straight to add()."""
+    import numpy as np
+    from ovos_m2v_pipeline import (MAX_ENTITY_EXPANSIONS,
+                                   PrototypeIntentStore)
+    store = PrototypeIntentStore()
+    model = mock.Mock()
+    model.encode.side_effect = \
+        lambda sents, **kw: np.ones((len(sents), 4), dtype=np.float32)
+    n = store.add(model, "big", [f"sentence {i}" for i in range(50000)])
+    assert n <= MAX_ENTITY_EXPANSIONS
+    sents_passed = model.encode.call_args[0][0]
+    assert len(sents_passed) == MAX_ENTITY_EXPANSIONS
+    assert sents_passed[0] == "sentence 0"
+    assert sents_passed[-1] == "sentence 49999"
+
+
+def test_padatious_labels_dealias_to_canonical():
+    """Dual-contract registration must collapse to ONE label, or the store
+    holds every prototype twice (observed live: 83 -> 116 labels, ~1.1M
+    prototypes)."""
+    import numpy as np
+    from ovos_utils.fakebus import FakeBus
+    from ovos_bus_client.message import Message
+    from ovos_m2v_pipeline import Model2VecPrototypePipeline
+    p = Model2VecPrototypePipeline.__new__(Model2VecPrototypePipeline)
+    p.ignore_labels = set()
+    p.intents = set()
+    p.model = mock.Mock()
+    p.model.encode.side_effect = \
+        lambda sents, **kw: np.ones((len(sents), 4), dtype=np.float32)
+    from ovos_m2v_pipeline import PrototypeIntentStore
+    p.prototype_store = PrototypeIntentStore()
+    p._prototype_k = None
+    p._handle_register_padatious(Message(
+        "padatious:register_intent",
+        {"name": "skill.test:go.intent", "samples": ["go to work"]}))
+    assert "skill.test:go" in p.intents
+    assert "skill.test:go.intent" not in p.intents
+    # detach with the suffixed name removes the canonical entry
+    p._handle_detach_intent(Message(
+        "detach_intent", {"intent_name": "skill.test:go.intent"}))
+    assert len(p.prototype_store) == 0

--- a/tests/test_exact_sample_match.py
+++ b/tests/test_exact_sample_match.py
@@ -59,7 +59,7 @@ class TestExactSampleHighTierMatch(unittest.TestCase):
         self.assertIsNotNone(match)
         self.assertEqual(
             match.match_type,
-            "ovos-skill-date-time.openvoiceos:what.time.is.it.intent")
+            "ovos-skill-date-time.openvoiceos:what.time.is.it")
         self.assertGreaterEqual(match.match_data["confidence"], 0.99)
 
     def test_every_sample_kept_by_default(self):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -667,8 +667,8 @@ class TestPrototypeBusHandlers(unittest.TestCase):
                 "name": "skill_a:greet.intent",
                 "file_name": "/fake/greet.intent",
             }))
-        self.assertIn("skill_a:greet.intent", p.prototype_store.unique_labels)
-        self.assertIn("skill_a:greet.intent", p.intents)
+        self.assertIn("skill_a:greet", p.prototype_store.unique_labels)
+        self.assertIn("skill_a:greet", p.intents)
 
     def test_handle_register_padatious_updates_existing_label(self):
         p = self._pipeline()
@@ -684,7 +684,7 @@ class TestPrototypeBusHandlers(unittest.TestCase):
                 "name": "skill_a:greet.intent",
                 "file_name": "/fake/greet.intent",
             }))
-        self.assertEqual((p.prototype_store.labels == "skill_a:greet.intent").sum(), 1)
+        self.assertEqual((p.prototype_store.labels == "skill_a:greet").sum(), 1)
 
     def test_handle_register_padatious_inline_samples(self):
         p = self._pipeline()
@@ -693,8 +693,8 @@ class TestPrototypeBusHandlers(unittest.TestCase):
             "name": "skill_a:greet.intent",
             "samples": ["hello", "hi"],
         }))
-        self.assertIn("skill_a:greet.intent", p.prototype_store.unique_labels)
-        self.assertIn("skill_a:greet.intent", p.intents)
+        self.assertIn("skill_a:greet", p.prototype_store.unique_labels)
+        self.assertIn("skill_a:greet", p.intents)
 
     def test_handle_register_padatious_inline_samples_expand_template(self):
         """Inline samples with template syntax are expanded."""
@@ -705,7 +705,7 @@ class TestPrototypeBusHandlers(unittest.TestCase):
             "samples": ["(turn on|switch on) the lights"],
         }))
         # Two expanded variants should both be embedded
-        n_protos = (p.prototype_store.labels == "skill_a:lights.intent").sum()
+        n_protos = (p.prototype_store.labels == "skill_a:lights").sum()
         self.assertEqual(n_protos, 2)
 
     def test_handle_register_padatious_skips_missing_file(self):

--- a/tests/test_template_expansion.py
+++ b/tests/test_template_expansion.py
@@ -92,7 +92,7 @@ class TestRegisterPadatious(unittest.TestCase):
         with patch("ovos_m2v_pipeline.LOG.warning") as warn:
             pipeline._handle_register_padatious(
                 _padatious_msg(MALFORMED + VALID))
-        self.assertIn("test_skill:demo.intent", pipeline.intents)
+        self.assertIn("test_skill:demo", pipeline.intents)
         pipeline.prototype_store.add.assert_called_once()
         sentences = pipeline.prototype_store.add.call_args[0][2]
         self.assertIn("play {media}", sentences)
@@ -101,7 +101,7 @@ class TestRegisterPadatious(unittest.TestCase):
         for call in warn.call_args_list:
             log = call[0][0]
             self.assertIn("skipping malformed template", log)
-            for field in FIELDS + ["test_skill:demo.intent",
+            for field in FIELDS + ["test_skill:demo",
                                    "padatious:register_intent"]:
                 self.assertIn(field, log)
 
@@ -109,7 +109,7 @@ class TestRegisterPadatious(unittest.TestCase):
         pipeline = _make_prototype_pipeline()
         with patch("ovos_m2v_pipeline.LOG.warning") as warn:
             pipeline._handle_register_padatious(_padatious_msg(list(MALFORMED)))
-        self.assertNotIn("test_skill:demo.intent", pipeline.intents)
+        self.assertNotIn("test_skill:demo", pipeline.intents)
         pipeline.prototype_store.add.assert_not_called()
         rejection = warn.call_args_list[-1][0][0]
         self.assertIn("rejecting registration", rejection)
@@ -124,12 +124,12 @@ class TestRegisterPadatious(unittest.TestCase):
             with open(path, "w", encoding="utf-8") as fh:
                 fh.write("\n".join(MALFORMED + VALID))
             msg = Message("padatious:register_intent",
-                          data={"name": "test_skill:demo.intent",
+                          data={"name": "test_skill:demo",
                                 "skill_id": "test_skill", "lang": "en-US",
                                 "file_name": path})
             with patch("ovos_m2v_pipeline.LOG.warning") as warn:
                 pipeline._handle_register_padatious(msg)
-        self.assertIn("test_skill:demo.intent", pipeline.intents)
+        self.assertIn("test_skill:demo", pipeline.intents)
         pipeline.prototype_store.add.assert_called_once()
         for call in warn.call_args_list:
             for field in FIELDS:
@@ -145,7 +145,7 @@ class TestRegisterPadatious(unittest.TestCase):
         pipeline.prototype_store.add.assert_not_called()
         pipeline._handle_register_padatious(
             _padatious_msg(list(VALID), lang="en-US"))
-        self.assertIn("test_skill:demo.intent", pipeline.intents)
+        self.assertIn("test_skill:demo", pipeline.intents)
         pipeline.prototype_store.add.assert_called_once()
 
 


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

The 0.5.5a1 acceptance boot on a real deployment REJECTED the previous fix: the store still built 1,169,221 prototypes for 116 labels, because the 2000-combination cap applied only on the entity slot-filling path while the samples actually arrive through the legacy `padatious:register_intent` handler as pre-expanded template lists — unbounded. And the label count RISING from 83 to 116 exposed a second defect: the dual-emit from ovos-workshop registers the same intent under the `.intent`-suffixed legacy name and the suffixless spec name, and this plugin stored both — every prototype held twice.

Two fixes. The sample bound moves to the single choke point, `PrototypeIntentStore.add`: any batch over 2000 sentences is evenly sampled at ingest, whatever path materialized it. And padatious-contract labels are dealiased to the canonical suffixless form on registration, detach, and `ignore_labels` (both forms accepted in config), so dual-contract registrations collapse to one label and matches dispatch on the same canonical id padatious itself uses — aligning with the dealiasing already shipped in ovos-padatious and ovoscope.

Tests: ingest-bound pinned with a 50k-sentence batch (endpoints kept, even sampling), dual-contract collapse pinned end-to-end (suffixed registration → canonical label → suffixed detach removes it), and the handler tests keep registering with the suffixed wire name so the dealias path stays exercised; suffixed-label assertions updated deliberately — they pinned the double-storage defect. Full suite: 162 passed, 2 skipped. Docs: prerelease-quirks entries. The rejected boot's instrumentation is standing by for the acceptance re-run on 0.5.6a1.
