### PR TITLE
fix: amortize prototype-store growth and log build progress

### DIFF
--- a/docs/prerelease-quirks.md
+++ b/docs/prerelease-quirks.md
@@ -3,6 +3,17 @@
 Behavior changes since the last stable release, newest first. This file is
 reset at each stable release.
 
+## 0.5.7a1
+
+- Prototype-store growth is amortized: registrations buffer into pending
+  chunks and consolidate once on first read (match, save, or property
+  access). Previously every registration re-stacked the entire embedding
+  array — quadratic build cost, measured as a 1.2GB array reallocated per
+  skill on a real install, which is why store construction took tens of
+  minutes with one core pegged. Each registration also logs an INFO
+  progress line (prototypes added, running totals) so long builds are
+  visible instead of looking like an idle hang.
+
 ## 0.5.6a1
 
 - The sample bound applies at store ingest, whatever path materialized the

--- a/ovos_m2v_pipeline/__init__.py
+++ b/ovos_m2v_pipeline/__init__.py
@@ -100,6 +100,26 @@ class PrototypeIntentStore:
         else:
             self._embeddings = np.empty((0, 0), dtype=np.float32)
             self._labels = np.array([], dtype=object)
+        #: chunks appended by add() and stacked lazily: one vstack per add
+        #: copies the whole store every registration (quadratic build cost,
+        #: measured as a 1.2GB array reallocated per skill on real installs)
+        self._pending: List[tuple] = []
+        self._label_set = set(np.unique(self._labels)) if len(self._labels) else set()
+
+    def _consolidate(self) -> None:
+        """Stack pending chunks into the contiguous arrays, once."""
+        if not self._pending:
+            return
+        chunks = [c for c, _ in self._pending]
+        label_chunks = [l for _, l in self._pending]
+        if len(self._labels):
+            self._embeddings = np.vstack([self._embeddings] + chunks)
+            self._labels = np.concatenate([self._labels] + label_chunks)
+        else:
+            self._embeddings = np.vstack(chunks) if len(chunks) > 1 else chunks[0]
+            self._labels = (np.concatenate(label_chunks)
+                            if len(label_chunks) > 1 else label_chunks[0])
+        self._pending.clear()
 
     # ------------------------------------------------------------------
     # Public read-only views
@@ -107,18 +127,22 @@ class PrototypeIntentStore:
 
     @property
     def embeddings(self) -> np.ndarray:
-        return self._embeddings
+        with self._lock:
+            self._consolidate()
+            return self._embeddings
 
     @property
     def labels(self) -> np.ndarray:
-        return self._labels
+        with self._lock:
+            self._consolidate()
+            return self._labels
 
     @property
     def unique_labels(self) -> np.ndarray:
-        return np.unique(self._labels)
+        return np.unique(self.labels)
 
     def __len__(self) -> int:
-        return len(self._labels)
+        return len(self._labels) + sum(len(l) for _, l in self._pending)
 
     # ------------------------------------------------------------------
     # Mutation
@@ -173,37 +197,45 @@ class PrototypeIntentStore:
         ).astype(np.float32)
         n_added = len(anchors)
         with self._lock:
-            self.remove(label)
+            if label in self._label_set:
+                # re-registration: fold pending in, then drop the old rows
+                self._consolidate()
+                mask = self._labels != label
+                self._embeddings = self._embeddings[mask]
+                self._labels = self._labels[mask]
+                self._label_set.discard(label)
             if n_added == 0:
                 return 0
-            if not len(self):
-                self._embeddings = anchors
-                self._labels = np.array([label] * n_added, dtype=object)
-            else:
-                self._embeddings = np.vstack([self._embeddings, anchors])
-                self._labels = np.concatenate(
-                    [self._labels, np.array([label] * n_added, dtype=object)]
-                )
+            self._pending.append(
+                (anchors, np.array([label] * n_added, dtype=object)))
+            self._label_set.add(label)
+            LOG.info(f"prototype store: +{n_added} prototypes for "
+                     f"{label!r} ({len(self)} total, "
+                     f"{len(self._label_set)} labels)")
         return n_added
 
     def remove(self, label: str) -> None:
         """Remove all prototypes for *label*."""
         with self._lock:
-            if not len(self):
+            if label not in self._label_set:
                 return
+            self._consolidate()
             mask = self._labels != label
             self._embeddings = self._embeddings[mask]
             self._labels = self._labels[mask]
+            self._label_set.discard(label)
 
     def remove_skill(self, skill_id: str) -> None:
         """Remove all prototypes whose label starts with ``<skill_id>:``."""
         with self._lock:
             if not len(self):
                 return
+            self._consolidate()
             prefix = skill_id + ":"
             mask = np.array([not str(lbl).startswith(prefix) for lbl in self._labels])
             self._embeddings = self._embeddings[mask]
             self._labels = self._labels[mask]
+            self._label_set = set(np.unique(self._labels)) if len(self._labels) else set()
 
     # ------------------------------------------------------------------
     # Inference
@@ -220,6 +252,7 @@ class PrototypeIntentStore:
         with self._lock:
             if not len(self):
                 return {}
+            self._consolidate()
             embeddings, labels = self._embeddings, self._labels
         q = query_embedding.astype(np.float32)
         norm = np.linalg.norm(q)
@@ -263,6 +296,7 @@ class PrototypeIntentStore:
     def save(self, path: str) -> None:
         """Save to a NumPy ``.npz`` archive."""
         with self._lock:
+            self._consolidate()
             np.savez(path, embeddings=self._embeddings, labels=self._labels.astype(str))
         LOG.info(
             f"Saved {len(self)} prototypes "

--- a/tests/test_encode_bounded.py
+++ b/tests/test_encode_bounded.py
@@ -87,3 +87,26 @@ def test_padatious_labels_dealias_to_canonical():
     p._handle_detach_intent(Message(
         "detach_intent", {"intent_name": "skill.test:go.intent"}))
     assert len(p.prototype_store) == 0
+
+
+def test_store_add_is_amortized_no_per_add_vstack():
+    """Each add must not copy the whole store (O(n^2) build churn: a 1.2GB
+    array reallocated per registration on real installs). Adds buffer into
+    pending chunks; consolidation happens once on read."""
+    import numpy as np
+    from ovos_m2v_pipeline import PrototypeIntentStore
+    store = PrototypeIntentStore()
+    model = mock.Mock()
+    model.encode.side_effect = \
+        lambda sents, **kw: np.ones((len(sents), 4), dtype=np.float32)
+    for i in range(50):
+        store.add(model, f"label{i}", [f"s{i}a", f"s{i}b"])
+        assert len(store._pending) == i + 1  # no consolidation during adds
+    assert len(store) == 100
+    labels = store.labels  # first read consolidates, once
+    assert len(labels) == 100
+    assert len(store._pending) == 0
+    # re-registration replaces, through the consolidation path
+    store.add(model, "label0", ["new"])
+    assert (store.labels == "label0").sum() == 1
+    assert len(store) == 99


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

Measured on a clean 11-skill install (no big-entity skills): store construction reallocated the same two blocks ever larger — `np.vstack([self._embeddings, anchors])` on every registration copies the entire store, a 1.2GB array re-stacked per skill by the end. That quadratic churn, not just raw size, is why builds ran tens of minutes with one core pegged while the service "looked idle", and it compounds with however many prototypes survive the ingest cap.

Adds now buffer into pending chunks and consolidate exactly once on first read (match, save, or a property access); re-registration and removals fold pending in before masking, and a per-registration INFO line (prototypes added, running totals) makes long builds visible instead of indistinguishable from a hang. Membership is tracked in a set so the common first-registration path never triggers consolidation.

A regression test pins the amortization (50 adds, zero consolidations until the first read, replace-on-reregister through the consolidation path); fail-before verified by patch-revert. Full suite: 163 passed, 2 skipped. Docs: prerelease-quirks entry for 0.5.7a1. Diagnosis credit: the skills-QA lane's clean-install tracemalloc capture named the vstack line verbatim.
