### PR TITLE
fix: lazy bounded template expansion in all registration paths

### DIFF
--- a/docs/prerelease-quirks.md
+++ b/docs/prerelease-quirks.md
@@ -3,6 +3,15 @@
 Behavior changes since the last stable release, newest first. This file is
 reset at each stable release.
 
+## 0.5.8a1
+
+- Template expansion in every registration path is lazy and bounded:
+  `islice(iter_expand(...))` (ovos-spec-tools 1.8.0a1) replaces
+  materializing `expand` calls, so a combinatorial template costs what the
+  bound takes — registration-time expansion previously materialized full
+  cartesian products transiently (~3GB and ~20 minutes measured on a real
+  deployment) even though the store then kept at most 2000 samples.
+
 ## 0.5.7a1
 
 - Prototype-store growth is amortized: registrations buffer into pending

--- a/ovos_m2v_pipeline/__init__.py
+++ b/ovos_m2v_pipeline/__init__.py
@@ -13,7 +13,9 @@ from ovos_config.config import Configuration
 from ovos_plugin_manager.templates.pipeline import IntentHandlerMatch, ConfidenceMatcherPipeline
 from ovos_spec_tools import SpecMessage
 from ovos_spec_tools.context import gate_satisfied
-from ovos_spec_tools.expansion import expand as expand_template
+from itertools import islice
+
+from ovos_spec_tools.expansion import iter_expand
 from ovos_utils.fakebus import FakeBus
 from ovos_utils.log import LOG
 
@@ -339,7 +341,11 @@ def _parse_intent_file(path: str, ctx: str = "") -> List[str]:
                 line = line.strip()
                 if line and not line.lstrip().startswith("#"):
                     try:
-                        sentences.extend(expand_template(line))
+                        # lazy + bounded: a combinatorial template must
+                        # not materialize its full product just to be
+                        # sampled down at store ingest
+                        sentences.extend(islice(iter_expand(line),
+                                                MAX_ENTITY_EXPANSIONS))
                     except Exception as exc:
                         LOG.warning(f"skipping malformed template {line!r}: "
                                     f"{exc} {ctx}")
@@ -600,7 +606,7 @@ class Model2VecIntentPipeline(ConfidenceMatcherPipeline):
 
         ``message.data["samples"]`` (pre-expanded list) is preferred when
         present; otherwise the file at ``message.data["file_name"]`` is read
-        and its template syntax is expanded via ``expand_template``.
+        and its template syntax is expanded lazily via ``iter_expand``.
         """
         name: str = message.data.get("name", "")
         if name.endswith(".intent"):
@@ -621,7 +627,8 @@ class Model2VecIntentPipeline(ConfidenceMatcherPipeline):
             sentences: List[str] = []
             for s in inline:
                 try:
-                    sentences.extend(expand_template(s))
+                    sentences.extend(islice(iter_expand(s),
+                                            MAX_ENTITY_EXPANSIONS))
                 except Exception as exc:
                     LOG.warning(f"skipping malformed template {s!r}: {exc} {ctx}")
         else:
@@ -800,8 +807,12 @@ class Model2VecIntentPipeline(ConfidenceMatcherPipeline):
 
         expanded: List[str] = []
         for s in self._expand_entities(list(samples)):
+            if len(expanded) >= MAX_ENTITY_EXPANSIONS:
+                break
             try:
-                expanded.extend(expand_template(s))
+                expanded.extend(islice(
+                    iter_expand(s),
+                    MAX_ENTITY_EXPANSIONS - len(expanded)))
             except Exception as exc:
                 # skip the unparsable template, keep the valid ones (§6.3)
                 LOG.warning(
@@ -844,8 +855,10 @@ class Model2VecIntentPipeline(ConfidenceMatcherPipeline):
             return  # classifier model is frozen; no slot-fill to perform
         values: set = set()
         for s in samples:
+            if len(values) >= MAX_ENTITY_EXPANSIONS:
+                break
             try:
-                for v in expand_template(s):
+                for v in islice(iter_expand(s), MAX_ENTITY_EXPANSIONS):
                     v = v.strip()
                     if v:
                         values.add(v)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "ovos-bus-client>=2.5.1a1,<3.0.0",
     "ovos-config",
     "ovos-utils>=0.3.4,<1.0.0",
-    "ovos-spec-tools>=1.4.0a1",
+    "ovos-spec-tools>=1.8.0a1",
     "model2vec[inference]",
 ]
 
@@ -37,7 +37,7 @@ test = [
     # INTENT-4 consumer e2e stack floor (ovos.intent.register.* topics +
     # E2EPipelineHarness namespace flags). Mirrors ovos-test-harness@dev.
     "ovos-bus-client>=2.5.1a1,<3.0.0",
-    "ovos-spec-tools>=1.4.0a1",
+    "ovos-spec-tools>=1.8.0a1",
 ]
 
 [project.urls]


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

The round-2 acceptance boot showed the ingest cap working (37,332 prototypes, down from 1.17M) while construction still pinned the 2G cgroup for 21 minutes — because the cost was never the store: every registration path materialized the full cartesian product via `expand` before the cap could apply, ~3GB of transient strings on a real deployment.

All four expansion sites (intent-file parsing, inline padatious samples, INTENT-4 template samples, entity value sets) now consume `islice(iter_expand(...))` from ovos-spec-tools 1.8.0a1 — the generator yields identical samples in identical order, so a bounded consumer pays for exactly what it keeps. The spec-tools floor moves to the release that ships the generator.

Full suite: 163 passed, 2 skipped (the existing template-expansion and ingest-bound tests exercise the new path throughout). Docs: prerelease-quirks entry for 0.5.8a1. This completes the registration-path remediation: capped ingest (0.5.6a1), amortized store growth (0.5.7a1), and bounded generation (this PR) — the ser9 round-3 acceptance boot runs against this release.
